### PR TITLE
fix #245 by making sure string columns always have a max_length >= 1

### DIFF
--- a/src/DfWriter.cpp
+++ b/src/DfWriter.cpp
@@ -248,7 +248,7 @@ public:
         readstat_label_string_value(labelSet, string_utf8(values, i), string_utf8(labels, i));
     }
 
-    int max_length = 0;
+    int max_length = 1;
     for (int i = 0; i < x.size(); ++i) {
       int length = std::string(x[i]).size();
       if (length > max_length)

--- a/src/readstat/sas/readstat_sas7bdat_write.c
+++ b/src/readstat/sas/readstat_sas7bdat_write.c
@@ -144,7 +144,18 @@ static readstat_error_t sas7bdat_emit_header(readstat_writer_t *writer, sas_head
     };
 
     memcpy(&header_start.magic, sas7bdat_magic_number, sizeof(header_start.magic));
-    strncpy(header_start.file_label, writer->file_label, sizeof(header_start.file_label));
+
+    memset(header_start.file_label, ' ', sizeof(header_start.file_label));
+
+    size_t file_label_len = strlen(writer->file_label);
+    if (file_label_len > sizeof(header_start.file_label))
+        file_label_len = sizeof(header_start.file_label);
+
+    if (file_label_len) {
+        memcpy(header_start.file_label, writer->file_label, file_label_len);
+    } else {
+        memcpy(header_start.file_label, "DATASET", sizeof("DATASET")-1);
+    }
 
     return sas_write_header(writer, hinfo, header_start);
 }

--- a/src/readstat/spss/readstat_sav_write.c
+++ b/src/readstat/spss/readstat_sav_write.c
@@ -907,7 +907,9 @@ static size_t sav_variable_width(readstat_type_t type, size_t user_width) {
             size_t last_segment_width = ((user_width - (n_segments - 1) * 252) + 7)/8*8;
             return (n_segments-1)*256 + last_segment_width;
         }
-
+        if (user_width == 0) {
+            return 8;
+        }
         return (user_width + 7) / 8 * 8;
     }
     return 8;

--- a/src/readstat/stata/readstat_dta.h
+++ b/src/readstat/stata/readstat_dta.h
@@ -11,11 +11,19 @@ typedef struct dta_header_s {
     int32_t          nobs;
 } dta_header_t;
 
-typedef struct dta_strl_header_s {
-    unsigned char   vo_bytes[8];
+typedef struct dta_117_strl_header_s {
+    uint32_t        v;
+    uint32_t        o;
     unsigned char   type;
     int32_t         len;
-} dta_strl_header_t;
+} dta_117_strl_header_t;
+
+typedef struct dta_118_strl_header_s {
+    uint32_t        v;
+    uint64_t        o;
+    unsigned char   type;
+    int32_t         len;
+} dta_118_strl_header_t;
 
 #pragma pack(pop)
 

--- a/src/readstat/stata/readstat_dta_parse_timestamp.c
+++ b/src/readstat/stata/readstat_dta_parse_timestamp.c
@@ -19,37 +19,37 @@ static const char _dta_timestamp_parse_actions[] = {
 };
 
 static const char _dta_timestamp_parse_key_offsets[] = {
-	0, 0, 3, 5, 8, 16, 20, 21, 
-	22, 24, 27, 30, 33, 35, 36, 37, 
-	38, 39, 41, 42, 43, 44, 46, 47, 
-	48, 49, 53, 54, 55, 57, 58, 59, 
-	60, 62, 64, 66, 67, 68, 70, 72, 
-	73, 74, 75, 77, 78, 79, 80, 82, 
-	83, 84, 85
+	0, 0, 3, 5, 8, 24, 28, 30, 
+	31, 33, 36, 39, 42, 44, 46, 47, 
+	49, 53, 54, 56, 58, 59, 63, 65, 
+	66, 70, 71, 72, 74, 80, 81, 82, 
+	84, 86, 87, 91, 93, 94, 96, 98, 
+	99
 };
 
 static const char _dta_timestamp_parse_trans_keys[] = {
 	32, 48, 57, 48, 57, 32, 48, 57, 
 	65, 68, 70, 74, 77, 78, 79, 83, 
-	80, 85, 112, 117, 82, 32, 48, 57, 
-	32, 48, 57, 32, 48, 57, 58, 48, 
-	57, 48, 57, 71, 32, 114, 103, 69, 
-	101, 67, 32, 99, 69, 101, 66, 32, 
-	98, 65, 85, 97, 117, 78, 32, 76, 
-	78, 32, 32, 110, 108, 110, 65, 97, 
-	82, 89, 32, 32, 114, 121, 79, 111, 
-	86, 32, 118, 67, 99, 84, 32, 116, 
-	69, 101, 80, 32, 112, 48, 57, 0
+	97, 100, 102, 106, 109, 110, 111, 115, 
+	80, 85, 112, 117, 82, 114, 32, 48, 
+	57, 32, 48, 57, 32, 48, 57, 58, 
+	48, 57, 48, 57, 71, 103, 32, 69, 
+	101, 67, 90, 99, 122, 32, 69, 101, 
+	66, 98, 32, 65, 85, 97, 117, 78, 
+	110, 32, 76, 78, 108, 110, 32, 32, 
+	65, 97, 73, 82, 89, 105, 114, 121, 
+	32, 32, 79, 111, 86, 118, 32, 67, 
+	75, 99, 107, 84, 116, 32, 69, 101, 
+	80, 112, 32, 48, 57, 0
 };
 
 static const char _dta_timestamp_parse_single_lengths[] = {
-	0, 1, 0, 1, 8, 4, 1, 1, 
-	0, 1, 1, 1, 0, 1, 1, 1, 
-	1, 2, 1, 1, 1, 2, 1, 1, 
-	1, 4, 1, 1, 2, 1, 1, 1, 
-	2, 2, 2, 1, 1, 2, 2, 1, 
-	1, 1, 2, 1, 1, 1, 2, 1, 
-	1, 1, 0
+	0, 1, 0, 1, 16, 4, 2, 1, 
+	0, 1, 1, 1, 0, 2, 1, 2, 
+	4, 1, 2, 2, 1, 4, 2, 1, 
+	4, 1, 1, 2, 6, 1, 1, 2, 
+	2, 1, 4, 2, 1, 2, 2, 1, 
+	0
 };
 
 static const char _dta_timestamp_parse_range_lengths[] = {
@@ -58,58 +58,56 @@ static const char _dta_timestamp_parse_range_lengths[] = {
 	0, 0, 0, 0, 0, 0, 0, 0, 
 	0, 0, 0, 0, 0, 0, 0, 0, 
 	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 1
+	1
 };
 
 static const unsigned char _dta_timestamp_parse_index_offsets[] = {
-	0, 0, 3, 5, 8, 17, 22, 24, 
-	26, 28, 31, 34, 37, 39, 41, 43, 
-	45, 47, 50, 52, 54, 56, 59, 61, 
-	63, 65, 70, 72, 74, 77, 79, 81, 
-	83, 86, 89, 92, 94, 96, 99, 102, 
-	104, 106, 108, 111, 113, 115, 117, 120, 
-	122, 124, 126
+	0, 0, 3, 5, 8, 25, 30, 33, 
+	35, 37, 40, 43, 46, 48, 51, 53, 
+	56, 61, 63, 66, 69, 71, 76, 79, 
+	81, 86, 88, 90, 93, 100, 102, 104, 
+	107, 110, 112, 117, 120, 122, 125, 128, 
+	130
+};
+
+static const char _dta_timestamp_parse_indicies[] = {
+	0, 2, 1, 2, 1, 3, 4, 1, 
+	5, 6, 7, 8, 9, 10, 11, 12, 
+	5, 6, 7, 8, 9, 10, 11, 12, 
+	1, 13, 14, 13, 14, 1, 15, 15, 
+	1, 16, 1, 17, 1, 18, 19, 1, 
+	20, 21, 1, 23, 22, 1, 24, 1, 
+	25, 25, 1, 26, 1, 27, 27, 1, 
+	28, 28, 28, 28, 1, 29, 1, 30, 
+	30, 1, 31, 31, 1, 32, 1, 33, 
+	34, 33, 34, 1, 35, 35, 1, 36, 
+	1, 37, 38, 37, 38, 1, 39, 1, 
+	40, 1, 41, 41, 1, 42, 43, 42, 
+	42, 43, 42, 1, 44, 1, 45, 1, 
+	46, 46, 1, 47, 47, 1, 48, 1, 
+	49, 49, 49, 49, 1, 50, 50, 1, 
+	51, 1, 52, 52, 1, 53, 53, 1, 
+	54, 1, 55, 1, 0
 };
 
 static const char _dta_timestamp_parse_trans_targs[] = {
-	2, 3, 0, 3, 0, 4, 3, 0, 
-	5, 17, 21, 25, 33, 38, 42, 46, 
-	0, 6, 13, 15, 16, 0, 7, 0, 
-	8, 0, 9, 0, 10, 9, 0, 10, 
-	11, 0, 12, 11, 0, 50, 0, 14, 
-	0, 8, 0, 7, 0, 14, 0, 18, 
-	20, 0, 19, 0, 8, 0, 19, 0, 
-	22, 24, 0, 23, 0, 8, 0, 23, 
-	0, 26, 28, 31, 32, 0, 27, 0, 
-	8, 0, 29, 30, 0, 8, 0, 8, 
-	0, 27, 0, 29, 30, 0, 34, 37, 
-	0, 35, 36, 0, 8, 0, 8, 0, 
-	35, 36, 0, 39, 41, 0, 40, 0, 
-	8, 0, 40, 0, 43, 45, 0, 44, 
-	0, 8, 0, 44, 0, 47, 49, 0, 
-	48, 0, 8, 0, 48, 0, 50, 0, 
-	0
+	2, 0, 3, 4, 3, 5, 15, 18, 
+	21, 27, 31, 34, 37, 6, 13, 7, 
+	8, 9, 10, 9, 10, 11, 11, 12, 
+	40, 14, 8, 16, 17, 8, 19, 20, 
+	8, 22, 24, 23, 8, 25, 26, 8, 
+	8, 28, 29, 30, 8, 8, 32, 33, 
+	8, 35, 36, 8, 38, 39, 8, 40
 };
 
 static const char _dta_timestamp_parse_trans_actions[] = {
-	0, 35, 0, 35, 0, 3, 1, 0, 
+	0, 0, 35, 3, 1, 0, 0, 0, 
 	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	11, 0, 35, 0, 29, 1, 0, 0, 
-	35, 0, 31, 1, 0, 35, 0, 0, 
-	0, 19, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 27, 0, 0, 0, 
-	0, 0, 0, 0, 0, 7, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	5, 0, 0, 0, 0, 17, 0, 15, 
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 9, 0, 13, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	25, 0, 0, 0, 0, 0, 0, 0, 
-	0, 23, 0, 0, 0, 0, 0, 0, 
-	0, 0, 21, 0, 0, 0, 1, 0, 
-	0
+	11, 35, 29, 1, 0, 35, 1, 31, 
+	35, 0, 19, 0, 0, 27, 0, 0, 
+	7, 0, 0, 0, 5, 0, 0, 17, 
+	15, 0, 0, 0, 13, 9, 0, 0, 
+	25, 0, 0, 23, 0, 0, 21, 1
 };
 
 static const char _dta_timestamp_parse_eof_actions[] = {
@@ -118,8 +116,7 @@ static const char _dta_timestamp_parse_eof_actions[] = {
 	0, 0, 0, 0, 0, 0, 0, 0, 
 	0, 0, 0, 0, 0, 0, 0, 0, 
 	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 33
+	33
 };
 
 static const int dta_timestamp_parse_start = 1;
@@ -138,12 +135,12 @@ readstat_error_t dta_parse_timestamp(const char *data, size_t len, struct tm *ti
     int cs;
     int temp_val = 0;
     
-#line 142 "src/stata/readstat_dta_parse_timestamp.c"
+#line 139 "src/stata/readstat_dta_parse_timestamp.c"
 	{
 	cs = dta_timestamp_parse_start;
 	}
 
-#line 147 "src/stata/readstat_dta_parse_timestamp.c"
+#line 144 "src/stata/readstat_dta_parse_timestamp.c"
 	{
 	int _klen;
 	unsigned int _trans;
@@ -205,6 +202,7 @@ _resume:
 	}
 
 _match:
+	_trans = _dta_timestamp_parse_indicies[_trans];
 	cs = _dta_timestamp_parse_trans_targs[_trans];
 
 	if ( _dta_timestamp_parse_trans_actions[_trans] == 0 )
@@ -286,7 +284,7 @@ _match:
 #line 46 "src/stata/readstat_dta_parse_timestamp.rl"
 	{ timestamp->tm_hour = temp_val; }
 	break;
-#line 290 "src/stata/readstat_dta_parse_timestamp.c"
+#line 288 "src/stata/readstat_dta_parse_timestamp.c"
 		}
 	}
 
@@ -306,7 +304,7 @@ _again:
 #line 48 "src/stata/readstat_dta_parse_timestamp.rl"
 	{ timestamp->tm_min = temp_val; }
 	break;
-#line 310 "src/stata/readstat_dta_parse_timestamp.c"
+#line 308 "src/stata/readstat_dta_parse_timestamp.c"
 		}
 	}
 	}
@@ -317,7 +315,7 @@ _again:
 #line 54 "src/stata/readstat_dta_parse_timestamp.rl"
 
 
-    if (cs < 50|| p != pe) {
+    if (cs < 40|| p != pe) {
         if (ctx->error_handler) {
             snprintf(ctx->error_buf, sizeof(ctx->error_buf), "Invalid timestamp string (length=%d): %*s", (int)len, (int)-len, data);
             ctx->error_handler(ctx->error_buf, ctx->user_ctx);

--- a/src/readstat/stata/readstat_dta_read.c
+++ b/src/readstat/stata/readstat_dta_read.c
@@ -335,22 +335,49 @@ static void dta_interpret_strl_vo_bytes(dta_ctx_t *ctx, unsigned char *vo_bytes,
     }
 }
 
-static readstat_error_t dta_read_strl(dta_ctx_t *ctx, dta_strl_t *strl) {
+static readstat_error_t dta_117_read_strl(dta_ctx_t *ctx, dta_strl_t *strl) {
     readstat_error_t retval = READSTAT_OK;
     readstat_io_t *io = ctx->io;
-    dta_strl_header_t header;
+    dta_117_strl_header_t header;
 
-    if (io->read(&header, sizeof(header), io->io_ctx) != sizeof(dta_strl_header_t)) {
+    if (io->read(&header, sizeof(header), io->io_ctx) != sizeof(dta_117_strl_header_t)) {
         retval = READSTAT_ERROR_READ;
         goto cleanup;
     }
 
-    dta_interpret_strl_vo_bytes(ctx, header.vo_bytes, strl);
+    strl->v = ctx->bswap ? byteswap4(header.v) : header.v;
+    strl->o = ctx->bswap ? byteswap4(header.o) : header.o;
     strl->type = header.type;
     strl->len = ctx->bswap ? byteswap4(header.len) : header.len;
 
 cleanup:
     return retval;
+}
+
+static readstat_error_t dta_118_read_strl(dta_ctx_t *ctx, dta_strl_t *strl) {
+    readstat_error_t retval = READSTAT_OK;
+    readstat_io_t *io = ctx->io;
+    dta_118_strl_header_t header;
+
+    if (io->read(&header, sizeof(header), io->io_ctx) != sizeof(dta_118_strl_header_t)) {
+        retval = READSTAT_ERROR_READ;
+        goto cleanup;
+    }
+
+    strl->v = ctx->bswap ? byteswap4(header.v) : header.v;
+    strl->o = ctx->bswap ? byteswap8(header.o) : header.o;
+    strl->type = header.type;
+    strl->len = ctx->bswap ? byteswap4(header.len) : header.len;
+
+cleanup:
+    return retval;
+}
+
+static readstat_error_t dta_read_strl(dta_ctx_t *ctx, dta_strl_t *strl) {
+    if (ctx->strl_o_len > 4) {
+        return dta_118_read_strl(ctx, strl);
+    }
+    return dta_117_read_strl(ctx, strl);
 }
 
 static readstat_error_t dta_read_strls(dta_ctx_t *ctx) {


### PR DESCRIPTION
In https://github.com/WizardMac/ReadStat/commit/39793f9b0dcda35b47fb4796e4553e618c93125d which was integrated into haven at https://github.com/tidyverse/haven/commit/891bccaf314e725d1eac96475b6c5e363ff23479 new code was created to handle the writing of very large strings. However, in so doing, the line that automatically set string columns with width 0 to have a width of 255 was removed. When ReadStat tries to write a string column with width 0, this creates an infinite loop condition on this line https://github.com/WizardMac/ReadStat/blob/master/src/spss/readstat_sav_write.c#L210 since extra_fields starts at -1 and keeps decrementing, and therefore will never be 0, stopping the loop. One fix to this is in the present pull request, which simply makes the minimum length of a string column in haven 1, rather than 0. 

Another fix would be to ReadStat itself, at https://github.com/WizardMac/ReadStat/blob/master/src/spss/readstat_sav_write.c#L903 , to reintroduce the code that overrides a 0 width to 255 as it used to do here https://github.com/WizardMac/ReadStat/blob/085e04876b190a5b7f1d6ad6824c0fa8e74689b6/src/spss/readstat_sav_write.c#L748

I'm unsure which approach is the best, but fixing this issue in haven can't hurt.