### PR TITLE
Adds explicit link to libiconv

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -8,3 +8,4 @@ OBJECTS = $(CFILES:.c=.o) $(CPPFILES:.cpp=.o)
 
 PKG_CFLAGS = -Ireadstat
 PKG_CXXFLAGS = -Ireadstat
+PKG_LIBS=-liconv


### PR DESCRIPTION
Some linux distributions do not include `iconv` installed by default and therefore require the `libiconv` library to be explicitly linked to the package.  This PR makes that dependency explicit.

More details for the error one encounters otherwise can be found in Issue #299.