### PR TITLE
add invisible return for write_*(), update docs/news

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # haven 1.1.1.9000
 
-* `write_*()` now invisibly return the input data frame as documented (#349).
+* `write_*()` now invisibly return the input data frame as documented (#349, @austensen).
 
 * `write_xpt()` can now set the "member" name, which defaults to the file name
   san extension (#328).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # haven 1.1.1.9000
 
+* `write_*()` now invisibly return the input data frame as documented (#349).
+
 * `write_xpt()` can now set the "member" name, which defaults to the file name
   san extension (#328).
 

--- a/R/haven.R
+++ b/R/haven.R
@@ -23,6 +23,8 @@ NULL
 #'
 #'   Variable labels are stored in the "label" attribute of each variable.
 #'   It is not printed on the console, but the RStudio viewer will show it.
+#'
+#'   \code{write_sas()} returns the input \code{data} invisibly.
 #' @export
 #' @examples
 #' path <- system.file("examples", "iris.sas7bdat", package = "haven")
@@ -56,6 +58,7 @@ read_sas <- function(data_file, catalog_file = NULL,
 write_sas <- function(data, path) {
   validate_sas(data)
   write_sas_(data, normalizePath(path, mustWork = FALSE))
+  invisible(data)
 }
 
 #' Read and write SAS transport files
@@ -64,6 +67,12 @@ write_sas <- function(data, path) {
 #' of the data to the FDA.
 #'
 #' @inherit read_spss
+#' @return A tibble, data frame variant with nice defaults.
+#'
+#'   Variable labels are stored in the "label" attribute of each variable.
+#'   It is not printed on the console, but the RStudio viewer will show it.
+#'
+#'   \code{write_xpt()} returns the input \code{data} invisibly.
 #' @export
 #' @examples
 #' tmp <- tempfile(fileext = ".xpt")
@@ -98,6 +107,7 @@ write_xpt <- function(data, path, version = 8, name = NULL) {
     version = version,
     name = name
   )
+  invisible(data)
 }
 
 validate_xpt_name <- function(name, version) {
@@ -133,6 +143,8 @@ validate_xpt_name <- function(name, version) {
 #'
 #'   Variable labels are stored in the "label" attribute of each variable.
 #'   It is not printed on the console, but the RStudio viewer will show it.
+#'
+#'   \code{write_sav()} returns the input \code{data} invisibly.
 #' @name read_spss
 #' @examples
 #' path <- system.file("examples", "iris.sav", package = "haven")
@@ -178,6 +190,7 @@ read_por <- function(file, user_na = FALSE) {
 write_sav <- function(data, path, compress = FALSE) {
   validate_sav(data)
   write_sav_(data, normalizePath(path, mustWork = FALSE), compress = compress)
+  invisible(data)
 }
 
 
@@ -223,6 +236,8 @@ read_spss <- function(file, user_na = FALSE) {
 #'
 #'   Variable labels are stored in the "label" attribute of each variable.
 #'   It is not printed on the console, but the RStudio viewer will show it.
+#'
+#'   \code{write_dta()} returns the input \code{data} invisibly.
 #' @export
 #' @examples
 #' path <- system.file("examples", "iris.dta", package = "haven")
@@ -260,6 +275,7 @@ write_dta <- function(data, path, version = 14) {
     normalizePath(path, mustWork = FALSE),
     version = stata_file_format(version)
   )
+  invisible(data)
 }
 
 stata_file_format <- function(version) {

--- a/R/haven.R
+++ b/R/haven.R
@@ -24,7 +24,7 @@ NULL
 #'   Variable labels are stored in the "label" attribute of each variable.
 #'   It is not printed on the console, but the RStudio viewer will show it.
 #'
-#'   \code{write_sas()} returns the input \code{data} invisibly.
+#'   `write_sas()` returns the input `data` invisibly.
 #' @export
 #' @examples
 #' path <- system.file("examples", "iris.sas7bdat", package = "haven")
@@ -72,7 +72,7 @@ write_sas <- function(data, path) {
 #'   Variable labels are stored in the "label" attribute of each variable.
 #'   It is not printed on the console, but the RStudio viewer will show it.
 #'
-#'   \code{write_xpt()} returns the input \code{data} invisibly.
+#'   `write_xpt()` returns the input `data` invisibly.
 #' @export
 #' @examples
 #' tmp <- tempfile(fileext = ".xpt")
@@ -144,7 +144,7 @@ validate_xpt_name <- function(name, version) {
 #'   Variable labels are stored in the "label" attribute of each variable.
 #'   It is not printed on the console, but the RStudio viewer will show it.
 #'
-#'   \code{write_sav()} returns the input \code{data} invisibly.
+#'   `write_sav()` returns the input `data` invisibly.
 #' @name read_spss
 #' @examples
 #' path <- system.file("examples", "iris.sav", package = "haven")
@@ -237,7 +237,7 @@ read_spss <- function(file, user_na = FALSE) {
 #'   Variable labels are stored in the "label" attribute of each variable.
 #'   It is not printed on the console, but the RStudio viewer will show it.
 #'
-#'   \code{write_dta()} returns the input \code{data} invisibly.
+#'   `write_dta()` returns the input `data` invisibly.
 #' @export
 #' @examples
 #' path <- system.file("examples", "iris.dta", package = "haven")

--- a/man/read_dta.Rd
+++ b/man/read_dta.Rd
@@ -41,7 +41,7 @@ A tibble, data frame variant with nice defaults.
   Variable labels are stored in the "label" attribute of each variable.
   It is not printed on the console, but the RStudio viewer will show it.
 
-  \code{write_dta()} returns the input \code{data} invisibly.
+  `write_dta()` returns the input `data` invisibly.
 }
 \description{
 Currently haven can read and write logical, integer, numeric, character

--- a/man/read_dta.Rd
+++ b/man/read_dta.Rd
@@ -40,6 +40,8 @@ A tibble, data frame variant with nice defaults.
 
   Variable labels are stored in the "label" attribute of each variable.
   It is not printed on the console, but the RStudio viewer will show it.
+
+  \code{write_dta()} returns the input \code{data} invisibly.
 }
 \description{
 Currently haven can read and write logical, integer, numeric, character

--- a/man/read_sas.Rd
+++ b/man/read_sas.Rd
@@ -32,7 +32,7 @@ A tibble, data frame variant with nice defaults.
   Variable labels are stored in the "label" attribute of each variable.
   It is not printed on the console, but the RStudio viewer will show it.
 
-  \code{write_sas()} returns the input \code{data} invisibly.
+  `write_sas()` returns the input `data` invisibly.
 }
 \description{
 Reading supports both sas7bdat files and the accompanying sas7bdat files

--- a/man/read_sas.Rd
+++ b/man/read_sas.Rd
@@ -31,6 +31,8 @@ A tibble, data frame variant with nice defaults.
 
   Variable labels are stored in the "label" attribute of each variable.
   It is not printed on the console, but the RStudio viewer will show it.
+
+  \code{write_sas()} returns the input \code{data} invisibly.
 }
 \description{
 Reading supports both sas7bdat files and the accompanying sas7bdat files

--- a/man/read_spss.Rd
+++ b/man/read_spss.Rd
@@ -49,6 +49,8 @@ A tibble, data frame variant with nice defaults.
 
   Variable labels are stored in the "label" attribute of each variable.
   It is not printed on the console, but the RStudio viewer will show it.
+
+  \code{write_sav()} returns the input \code{data} invisibly.
 }
 \description{
 `read_sav()` reads both `.sav` and `.zsav` files; `write_sav()` creates

--- a/man/read_spss.Rd
+++ b/man/read_spss.Rd
@@ -50,7 +50,7 @@ A tibble, data frame variant with nice defaults.
   Variable labels are stored in the "label" attribute of each variable.
   It is not printed on the console, but the RStudio viewer will show it.
 
-  \code{write_sav()} returns the input \code{data} invisibly.
+  `write_sav()` returns the input `data` invisibly.
 }
 \description{
 `read_sav()` reads both `.sav` and `.zsav` files; `write_sav()` creates

--- a/man/read_xpt.Rd
+++ b/man/read_xpt.Rd
@@ -38,7 +38,7 @@ A tibble, data frame variant with nice defaults.
   Variable labels are stored in the "label" attribute of each variable.
   It is not printed on the console, but the RStudio viewer will show it.
 
-  \code{write_xpt()} returns the input \code{data} invisibly.
+  `write_xpt()` returns the input `data` invisibly.
 }
 \description{
 The SAS transport format is a open format, as is required for submission

--- a/man/read_xpt.Rd
+++ b/man/read_xpt.Rd
@@ -37,6 +37,8 @@ A tibble, data frame variant with nice defaults.
 
   Variable labels are stored in the "label" attribute of each variable.
   It is not printed on the console, but the RStudio viewer will show it.
+
+  \code{write_xpt()} returns the input \code{data} invisibly.
 }
 \description{
 The SAS transport format is a open format, as is required for submission


### PR DESCRIPTION
As discussed in #349, I added `invisible(data)` to all the `write_*()` functions. I then just followed the convention in `readr` for the update to the documentation and news.md entry. I didn't see any tests for invisible return in readr, and since the tests in haven are split up for each output type I didn't want to clutter things with this simple test. If you think it's worthwhile though, I can, of course, add the tests. 

This was what I was trying to confirm everything was working, so I could just add one of these for each type to the tests: 

```r
test_that("input data is invisibly returned", {
  df <- data.frame(x = 1:3)
  expect_equal(write_sas(df, tempfile()), df)
  expect_equal(write_xpt(df, tempfile()), df)
  expect_equal(write_dta(df, tempfile()), df)
  expect_equal(write_sav(df, tempfile()), df)
})
```

(I hope everything here is correct - this is my first PR and I wasn't sure about all the conventions)