### PR TITLE
Fix for converting to factor using option "labelled" when there are tagged nas

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,9 @@
   * Fixes out of memory error (#342)
   * Now supports reading and writing stata 15 files (#339)
 
+* Fix for `as_factor()` when the option levels="labels" and there are tagged NAs
+  (#340 @gergness)
+
 # haven 1.1.1
 
 * Update to latest readstat. Includes:

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,8 +17,8 @@
   * Fixes out of memory error (#342)
   * Now supports reading and writing stata 15 files (#339)
 
-* Fix for `as_factor()` when the option levels="labels" and there are tagged NAs
-  (#340 @gergness)
+* Fix for when `as_factor()` with option `levels="labels"` is used on tagged NAs
+  (#340, @gergness)
 
 # haven 1.1.1
 

--- a/R/as_factor.R
+++ b/R/as_factor.R
@@ -77,7 +77,8 @@ as_factor.labelled <- function(x, levels = c("default", "labels", "values", "bot
       labels = names(labels),
       values = levs
     )
-    x <- factor(x, levs, labels = labs, ordered = ordered)
+    x <- replace_with(x, levs, labs)
+    x <- factor(x, labs, ordered = ordered)
   }
 
   structure(x, label = label)

--- a/tests/testthat/test-labelled.R
+++ b/tests/testthat/test-labelled.R
@@ -38,6 +38,6 @@ test_that("given correct name in data frame", {
 })
 
 test_that("can convert to factor with using labels with labelled na's", {
- x <- labelled(c(1:2, tagged_na("a")), c(a = 1, c = tagged_na("a")))
+  x <- labelled(c(1:2, tagged_na("a")), c(a = 1, c = tagged_na("a")))
   expect_equal(as_factor(x, "labels"), factor(c("a", NA, "c")))
 })

--- a/tests/testthat/test-labelled.R
+++ b/tests/testthat/test-labelled.R
@@ -36,3 +36,8 @@ test_that("given correct name in data frame", {
   expect_named(data.frame(x), "x")
   expect_named(data.frame(y = x), "y")
 })
+
+test_that("can convert to factor with using labels with labelled na's", {
+ x <- labelled(c(1:2, tagged_na("a")), c(a = 1, c = tagged_na("a")))
+  expect_equal(as_factor(x, "labels"), factor(c("a", NA, "c")))
+})


### PR DESCRIPTION
Split out from #351 

In the current version of haven, `as_factor()` gets confused by tagged NAs when using the labels option.
``` r
library(haven)
x1 <- labelled(c(1, 2, tagged_na("a")), c(a = 1, b = tagged_na("a")))
as_factor(x1, "labels")
#> Error in factor(x, levs, labels = labs, ordered = ordered): invalid 'labels'; length 2 should be 1 or 1
```

After PR:
``` r
library(haven)
x1 <- labelled(c(1, 2, tagged_na("a")), c(a = 1, b = tagged_na("a")))
as_factor(x1, "labels")
#> [1] a    <NA> b   
#> Levels: a b
```

