### PR TITLE
Preserve labelled_spss class when subsetting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,9 @@
   * Fixes out of memory error (#342)
   * Now supports reading and writing stata 15 files (#339)
 
+* Subsetting `labelled_spss` values keeps the original class instead of converting
+  to `labelled` (#340 @gergness)
+
 * Fix for `as_factor()` when the option levels="labels" and there are tagged NAs
   (#340 @gergness)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,9 @@
   * Fixes out of memory error (#342)
   * Now supports reading and writing stata 15 files (#339)
 
+* Fix for `as_factor()` when the option levels="labels" and there are tagged NAs
+  (#340 @gergness)
+
 # haven 1.1.1
 
 * Update to latest readstat. Includes:

--- a/R/as_factor.R
+++ b/R/as_factor.R
@@ -77,7 +77,8 @@ as_factor.labelled <- function(x, levels = c("default", "labels", "values", "bot
       labels = names(labels),
       values = levs
     )
-    x <- factor(x, levs, labels = labs, ordered = ordered)
+    x <- replace_with(x, levs, labs)
+    x <- factor(x, labs, ordered = ordered)
   }
 
   structure(x, label = label)

--- a/R/labelled.R
+++ b/R/labelled.R
@@ -75,6 +75,11 @@ is.labelled <- function(x) inherits(x, "labelled")
 }
 
 #' @export
+`[.labelled_spss` <- function(x, ...) {
+  labelled_spss(NextMethod(), attr(x, "labels"), attr(x, "na_values"), attr(x, "na_range"))
+}
+
+#' @export
 print.labelled <- function(x, ..., digits = getOption("digits")) {
   cat("<Labelled ", typeof(x), ">\n", sep = "")
 

--- a/tests/testthat/test-labelled.R
+++ b/tests/testthat/test-labelled.R
@@ -36,3 +36,8 @@ test_that("given correct name in data frame", {
   expect_named(data.frame(x), "x")
   expect_named(data.frame(y = x), "y")
 })
+
+test_that("can convert to factor with using labels with labelled na's", {
+ x <- labelled(c(1:2, tagged_na("a")), c(a = 1, c = tagged_na("a")))
+  expect_equal(as_factor(x, "labels"), factor(c("a", NA, "c")))
+})

--- a/tests/testthat/test-labelled_spss.R
+++ b/tests/testthat/test-labelled_spss.R
@@ -22,6 +22,16 @@ test_that("printed output is stable", {
   expect_output_file(print(x), "labelled-spss-output.txt")
 })
 
+test_that("subsetting labelled_spss retains class", {
+  x <- labelled_spss(
+    1:5, c("Good" = 1, "Bad" = 5),
+    na_value = c(1, 2),
+    na_range = c(3, Inf)
+  )
+
+  expect_equal(class(x), class(x[1:2]))
+})
+
 
 # is.na -------------------------------------------------------------------
 

--- a/tests/testthat/test-labelled_spss.R
+++ b/tests/testthat/test-labelled_spss.R
@@ -29,7 +29,7 @@ test_that("subsetting labelled_spss retains class", {
     na_range = c(3, Inf)
   )
 
-  expect_equal(class(x), class(x[1:2]))
+  expect_identical(x, x[1:5])
 })
 
 


### PR DESCRIPTION
Hm, I'm at the edge of my git comfort level, so I'm not sure I've split this up in the best way. Is there a way to have it show the diffs only relative to my previous PR? 

This is the second part of #351, and includes #352. 

Before this PR:
Subsetting labelled_spss objects converts them to labelled class, losing their NA label attributes.
``` r
library(haven)
x2 <- labelled_spss(c(1, 2, 9), c(a = 1), na_values = 9)
is.na(x2)
#> [1] FALSE FALSE  TRUE
is.na(x2[1:3])
#> [1] FALSE FALSE FALSE
class(x2[1:3])
#> [1] "labelled"
```

After PR:
``` r
library(haven)
x2 <- labelled_spss(c(1, 2, 9), c(a = 1), na_values = 9)
is.na(x2)
#> [1] FALSE FALSE  TRUE
is.na(x2[1:3])
#> [1] FALSE FALSE  TRUE
class(x2[1:3])
#> [1] "labelled_spss" "labelled"
```
