### PR TITLE
Add release links to pkgdown site News

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -60,6 +60,10 @@ navbar:
   - text: News
     menu:
       - text: "Release notes"
+      - text: "Version 2.0.0"
+        href: https://www.tidyverse.org/articles/2019/01/haven-2-0-0/
+      - text: "Version 1.1.2"
+        href: https://www.tidyverse.org/articles/2018/06/haven-1-1-2/
       - text: "Version 1.0.0"
         href: articles/releases/haven-1.0.0.html
       - text: "Version 0.1.0"


### PR DESCRIPTION
* Add links in `_pkgdown.yml` to tidyverse.org articles for haven releases 1.1.2, and 2.0.0.