### PR TITLE
Replace data_frame with tibble

### DIFF
--- a/R/labelled.R
+++ b/R/labelled.R
@@ -107,7 +107,7 @@ print.haven_labelled <- function(x, ..., digits = getOption("digits")) {
 #' @examples
 #' s1 <- labelled(c("M", "M", "F"), c(Male = "M", Female = "F"))
 #' s2 <- labelled(c(1, 1, 2), c(Male = 1, Female = 2))
-#' labelled_df <- tibble::data_frame(s1, s2)
+#' labelled_df <- tibble::tibble(s1, s2)
 #'
 #' for (var in names(labelled_df)) {
 #'   print_labels(labelled_df[[var]], var)

--- a/R/zap_label.R
+++ b/R/zap_label.R
@@ -16,7 +16,7 @@
 #' zap_label(x2)
 #'
 #' # zap_label also works with data frames
-#' df <- tibble::data_frame(x1, x2)
+#' df <- tibble::tibble(x1, x2)
 #' df
 #' zap_label(df)
 zap_label <- function(x) {

--- a/R/zap_labels.R
+++ b/R/zap_labels.R
@@ -21,7 +21,7 @@
 #' zap_labels(x2)
 #'
 #' # zap_labels also works with data frames
-#' df <- tibble::data_frame(x1, x2)
+#' df <- tibble::tibble(x1, x2)
 #' df
 #' zap_labels(df)
 zap_labels <- function(x) {

--- a/R/zap_missing.R
+++ b/R/zap_missing.R
@@ -22,7 +22,7 @@
 #' zap_missing(x2)
 #'
 #' # You can also apply to data frames
-#' df <- tibble::data_frame(x1, x2, y = 4:1)
+#' df <- tibble::tibble(x1, x2, y = 4:1)
 #' df
 #' zap_missing(df)
 zap_missing <- function(x) {

--- a/man/print_labels.Rd
+++ b/man/print_labels.Rd
@@ -18,7 +18,7 @@ a newly imported dataset.
 \examples{
 s1 <- labelled(c("M", "M", "F"), c(Male = "M", Female = "F"))
 s2 <- labelled(c(1, 1, 2), c(Male = 1, Female = 2))
-labelled_df <- tibble::data_frame(s1, s2)
+labelled_df <- tibble::tibble(s1, s2)
 
 for (var in names(labelled_df)) {
   print_labels(labelled_df[[var]], var)

--- a/man/zap_label.Rd
+++ b/man/zap_label.Rd
@@ -23,7 +23,7 @@ x2
 zap_label(x2)
 
 # zap_label also works with data frames
-df <- tibble::data_frame(x1, x2)
+df <- tibble::tibble(x1, x2)
 df
 zap_label(df)
 }

--- a/man/zap_labels.Rd
+++ b/man/zap_labels.Rd
@@ -30,7 +30,7 @@ x2
 zap_labels(x2)
 
 # zap_labels also works with data frames
-df <- tibble::data_frame(x1, x2)
+df <- tibble::tibble(x1, x2)
 df
 zap_labels(df)
 }

--- a/man/zap_missing.Rd
+++ b/man/zap_missing.Rd
@@ -30,7 +30,7 @@ x2
 zap_missing(x2)
 
 # You can also apply to data frames
-df <- tibble::data_frame(x1, x2, y = 4:1)
+df <- tibble::tibble(x1, x2, y = 4:1)
 df
 zap_missing(df)
 }

--- a/tests/testthat/test-read-sav.R
+++ b/tests/testthat/test-read-sav.R
@@ -45,7 +45,7 @@ test_that("datetime values correctly imported (offset)", {
 })
 
 test_that("formats roundtrip", {
-  df <- tibble::data_frame(
+  df <- tibble::tibble(
     a = structure(c(1, 1, 2), format.spss = "F1.0"),
     b = structure(4:6, format.spss = "F2.1"),
     c = structure(7:9, format.spss = "N2"),
@@ -65,7 +65,7 @@ test_that("formats roundtrip", {
 })
 
 test_that("widths roundtrip", {
-  df <- tibble::data_frame(
+  df <- tibble::tibble(
     a = structure(c(1, 1, 2), display_width = 10),
     b = structure(4:6, display_width = 11),
     c = structure(7:9, display_width = 12),

--- a/tests/testthat/test-zap_label.R
+++ b/tests/testthat/test-zap_label.R
@@ -17,7 +17,7 @@ test_that("zap_label is correctly applied to every column in data frame", {
   y2_label <- labelled(1:10, c("bad" = 2), label="bar")
   y2_nolabel <- labelled(1:10, c("bad" = 2))
 
-  df <- tibble::data_frame(x = 1:10, y1=y1_label, y2=y2_label)
+  df <- tibble::tibble(x = 1:10, y1=y1_label, y2=y2_label)
   df_zapped <- zap_label(df)
 
   expect_equal(ncol(df_zapped), ncol(df))

--- a/tests/testthat/test-zap_labels.R
+++ b/tests/testthat/test-zap_labels.R
@@ -12,7 +12,7 @@ test_that("zap_labels returns variables not of class('labelled') unmodified", {
 })
 
 test_that("zap_labels is applied to every column in data frame", {
-  df <- tibble::data_frame(x = 1:10, y = labelled(10:1, c("good" = 1)))
+  df <- tibble::tibble(x = 1:10, y = labelled(10:1, c("good" = 1)))
   expect_equal(zap_labels(df)$y, 10:1)
 })
 

--- a/tests/testthat/test-zap_missing.R
+++ b/tests/testthat/test-zap_missing.R
@@ -19,7 +19,7 @@ test_that("converts user-defined missings", {
 test_that("converts data frame", {
   x1 <- labelled(tagged_na("a", "b"), c(a = tagged_na("a"), b = 1))
 
-  df1 <- tibble::data_frame(x1 = 1, x2 = 2:1)
+  df1 <- tibble::tibble(x1 = 1, x2 = 2:1)
   df2 <- zap_missing(df1)
 
   expect_equal(na_tag(df1$x1), c(NA_character_, NA))


### PR DESCRIPTION
This PR replaces calls of data_frame (deprecated) with tibble, per tidyverse/dplyr#4069 for Tidyverse Dev Day.