### PR TITLE
Add -liconv to src/Makevars

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -8,4 +8,4 @@ OBJECTS = $(CFILES:.c=.o) $(CPPFILES:.cpp=.o)
 
 PKG_CFLAGS = -Ireadstat -DHAVE_ZLIB
 PKG_CXXFLAGS = -Ireadstat -DHAVE_ZLIB
-PKG_LIBS = -lz
+PKG_LIBS = -lz -liconv


### PR DESCRIPTION
This addresses the problem reported in https://github.com/tidyverse/haven/issues/465 which causes install problems on Linux.