### PR TITLE
Add support for duplicated levels in as_factor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # haven (development version)
 
+* `as_factor()` now supports duplicated levels (#475).
+
 * `read_sas()` now supports (IS|E|B)8601(DT|DA|TM) date/time formats (@mikmart).
 
 * `read_*()` functions gain two new arguments (@mikmart):

--- a/R/as_factor.R
+++ b/R/as_factor.R
@@ -80,7 +80,7 @@ as_factor.haven_labelled <- function(x, levels = c("default", "labels", "values"
       values = levs
     )
     x <- replace_with(x, levs, labs)
-    x <- factor(x, labs, ordered = ordered)
+    x <- factor(x, unique(labs), ordered = ordered)
   }
 
   structure(x, label = label)

--- a/tests/testthat/test-as-factor.R
+++ b/tests/testthat/test-as-factor.R
@@ -18,6 +18,12 @@ test_that("variable label is kept when converting characters to factors (#178)",
 
 # Labelled values ---------------------------------------------------------
 
+test_that("duplicated labels do not prevent coercion when levels is 'labels' (#475)", {
+  s1 <- labelled(1:3, c("A" = 1, "B" = 2, "A" = 3))
+  exp <- factor(c("A", "B", "A"), levels = c("A", "B"))
+  expect_equal(as_factor(s1, levels = "labels"), exp)
+})
+
 test_that("all labels (implicit missing values) are preserved when levels is 'default' or 'both' (#172)", {
   s1 <- labelled(rep(1, 3), c("A" = 1, "B" = 2, "C" = 3))
   exp <- factor(rep("A", 3), levels = c("A", "B", "C"))


### PR DESCRIPTION
This addresses the issue #475 
The solution involves only adding a call to `unique()` around the labels when calling `factor()`.
I created a test that shows the problem in the original implementation.
I updated the NEWS file.