### PR TITLE
apply vec_data() on labels, in labelled()

### DIFF
--- a/R/labelled.R
+++ b/R/labelled.R
@@ -40,7 +40,7 @@
 #' zap_labels(x)
 labelled <- function(x = double(), labels = NULL, label = NULL) {
   x <- vec_data(x)
-  labels <- vec_cast_named(labels, x, x_arg = "labels", to_arg = "x")
+  labels <- vec_cast_named(vec_data(labels), x, x_arg = "labels", to_arg = "x")
   validate_labelled(new_labelled(x, labels = labels, label = label))
 }
 


### PR DESCRIPTION
This should really be harmless, and it allows allocating the labels a class.
For instance, class "tagged" in package https://github.com/dusadrian/mixed, to allow printing tagged NAs for other vectors than haven_labelled