### PR TITLE
Fixing write_dta labels checking, addressing #606

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # haven (development version)
 
+* `write_dta()` now correctly handles "labelled"-class numeric (double) variables 
+   that don't have value labels (@jmobrien, #606, #609).
+
 * Fix issue with `read_dta()` crashing R when StrL variables with missing values
   were present (@gorcha, #594, #600, #608).
 

--- a/R/haven-stata.R
+++ b/R/haven-stata.R
@@ -139,6 +139,10 @@ validate_dta_label <- function(label) {
 # helpers -----------------------------------------------------------------
 
 has_non_integer_labels <- function(x) {
+  if (is.null(attr(x, "labels"))) {
+    return(FALSE)
+  }
+
   if (!is.labelled(x)) {
     return(FALSE)
   }

--- a/tests/testthat/test-haven-stata.R
+++ b/tests/testthat/test-haven-stata.R
@@ -164,6 +164,7 @@ test_that("can write labelled with NULL labels", {
   chr <- labelled(c("a", "b"), NULL)
 
   expect_equal(roundtrip_var(int, "dta"), c(1L, 2L))
+  expect_equal(roundtrip_var(num, "dta"), c(1L, 2L))
   expect_equal(roundtrip_var(chr, "dta"), c("a", "b"))
 })
 


### PR DESCRIPTION
Addresses #606.

Added an initial check for missing labels in `has_non_integer_labels()`.  Previously, `as_integerish()` was returning FALSE when labels were missing.  

Also, associated test was missing an apparently-intended line that would have caught this.  Test passes now.   