### PR TITLE
Fix condition expectations in prevision of testthat breaking change

### DIFF
--- a/tests/testthat/test-haven-sas.R
+++ b/tests/testthat/test-haven-sas.R
@@ -140,8 +140,8 @@ test_that("can select columns when a catalog file is present", {
 })
 
 test_that("using cols_only warns about deprecation, but works", {
-  out <- expect_warning(
-    read_sas(test_path("sas/hadley.sas7bdat"), cols_only = "id"),
+  expect_warning(
+    out <- read_sas(test_path("sas/hadley.sas7bdat"), cols_only = "id"),
     "is deprecated"
   )
   expect_named(out, "id")


### PR DESCRIPTION
We are planning a breaking change to the condition expectations in testthat release (see NEWS item in https://github.com/r-lib/testthat/pull/1401). This PR implements a preventive fix that works with and without the breaking change.

There is no hurry to get this fix on CRAN since we are skipping one released version of testthat before going through with the change.
