### PR TITLE
Update haven-stata.R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # haven (development version)
 
+* `write_dta()` now allows variable names up to 32 characters (@sbae, #605).
+
 * Fix issue with `read_dta()` crashing R when StrL variables with missing values
   were present (@gorcha, #594, #600, #608).
 

--- a/R/haven-stata.R
+++ b/R/haven-stata.R
@@ -101,7 +101,7 @@ validate_dta <- function(data, version) {
 
   # Check variable names
   bad_name <- !grepl("^[A-Za-z_]{1}[A-Za-z0-9_]+$", names(data))
-  bad_length <- nchar(names(data)) > 31
+  bad_length <- nchar(names(data)) > 32
   bad_vars <- if (version >= 14) bad_length else bad_length || bad_name
   if (any(bad_vars)) {
     stop(


### PR DESCRIPTION
The maximum length of variable names in *.dta files was updated from 31 to 32. (See: https://www.stata.com/products/comparison-of-limits/)