### PR TITLE
Fix logic error in label deduping for labelled_spss()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # haven (development version)
 
+* The buglet fixed in 2.4.1 when combining `labelled()` with identical labels
+has been fixed in `labelled_spss()` (@gorcha, #599).
+
 # haven 2.4.1
 
 * Fix buglet when combining `labelled()` with identical labels.

--- a/R/labelled.R
+++ b/R/labelled.R
@@ -111,7 +111,7 @@ median.haven_labelled <- function(x, na.rm = TRUE, ...) {
 #' @export
 quantile.haven_labelled <- function(x, ...) {
   if (is.character(x)) {
-    abort("Can't compute median of labelled<character>")
+    abort("Can't compute quantile of labelled<character>")
   }
   quantile(vec_data(x), ...)
 }

--- a/R/labelled_spss.R
+++ b/R/labelled_spss.R
@@ -139,7 +139,7 @@ vec_ptype2.haven_labelled_spss.haven_labelled_spss <- function(x, y, ..., x_arg 
   # Prefer labels from LHS
   x_labels <- vec_cast_named(attr(x, "labels"), data_type, x_arg = x_arg)
   y_labels <- vec_cast_named(attr(y, "labels"), data_type, x_arg = y_arg)
-  labels <- c(x_labels, y_labels[setdiff(names(y_labels), names(x_labels))])
+  labels <- c(x_labels, y_labels[!y_labels %in% x_labels])
 
   # Prefer labels from LHS
   label <- attr(x, "label", exact = TRUE) %||% attr(y, "label", exact = TRUE)

--- a/tests/testthat/test-labelled_spss.R
+++ b/tests/testthat/test-labelled_spss.R
@@ -157,13 +157,21 @@ test_that("can combine names", {
   expect_named(vec_c(x, c(y = 1L)), c("x", "y"))
 })
 
-test_that("strip labels if different", {
+test_that("take labels from LHS", {
   expect_equal(
     vec_c(
       labelled_spss(1, labels = c(Good = 1, Bad = 5)),
       labelled_spss(5, labels = c(Bad = 1, Good = 5)),
     ),
     labelled_spss(c(1, 5), labels = c(Good = 1, Bad = 5))
+  )
+
+  expect_equal(
+    vec_c(
+      labelled_spss(1, labels = c(Good = 1)),
+      labelled_spss(5, labels = c(Bad = 1)),
+    ),
+    labelled_spss(c(1, 5), labels = c(Good = 1))
   )
 })
 


### PR DESCRIPTION
As noted in #599, this PR fixes the bug in ed2ddda853a244dd3dedb5de552cf74e8440d388 for `labelled_spss()` (plus an unrelated typo :slightly_smiling_face:)