### PR TITLE
Fix issue with read_dta crashing R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # haven (development version)
 
 * Fix issue with `read_dta()` crashing R when StrL variables with missing values
-were present (@gorcha, #600, #608).
+  were present (@gorcha, #594, #600, #608).
 
 # haven 2.4.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # haven (development version)
 
+* Fix issue with `read_dta()` crashing R when StrL variables with missing values
+were present (@gorcha, #600, #608).
+
 # haven 2.4.1
 
 * Fix buglet when combining `labelled()` with identical labels.

--- a/src/DfReader.cpp
+++ b/src/DfReader.cpp
@@ -363,8 +363,7 @@ public:
       } else if (readstat_value_is_system_missing(value)) {
         col[obs_index] = NA_STRING;
       } else if (str_value == NULL) {
-        const char empty_string[1] = { '\0' };
-        col[obs_index] = cpp11::r_string(empty_string);
+        col[obs_index] = cpp11::r_string("");
       } else {
         col[obs_index] = cpp11::r_string(str_value);
       }

--- a/src/DfReader.cpp
+++ b/src/DfReader.cpp
@@ -363,7 +363,8 @@ public:
       } else if (readstat_value_is_system_missing(value)) {
         col[obs_index] = NA_STRING;
       } else if (str_value == NULL) {
-        col[obs_index] = NA_STRING;
+        const char empty_string[1] = { '\0' };
+        col[obs_index] = cpp11::r_string(empty_string);
       } else {
         col[obs_index] = cpp11::r_string(str_value);
       }

--- a/src/DfReader.cpp
+++ b/src/DfReader.cpp
@@ -354,6 +354,7 @@ public:
     case READSTAT_TYPE_STRING:
     {
       cpp11::writable::strings col(output_[var_index]);
+      const char* str_value = readstat_string_value(value);
 
       if (readstat_value_is_tagged_missing(value)) {
         col[obs_index] = NA_STRING;
@@ -361,8 +362,10 @@ public:
         col[obs_index] = NA_STRING;
       } else if (readstat_value_is_system_missing(value)) {
         col[obs_index] = NA_STRING;
+      } else if (str_value == NULL) {
+        col[obs_index] = NA_STRING;
       } else {
-        col[obs_index] = cpp11::r_string(readstat_string_value(value));
+        col[obs_index] = cpp11::r_string(str_value);
       }
       break;
     }


### PR DESCRIPTION
The updates for cpp11 reintroduced the bug in #79 when read_dta is used on a file that has empty values in an StrL variable (#600, #608). This PR restores the old behaviour and returns an NA for these observations.

@hadley, the [StrL section of the dta spec](https://www.stata.com/help.cgi?dta#strls_vo) says that a NULL (i.e. no StrL address) should be interpreted as the empty string `""` rather than a missing value, so `NA_STRING` might not actually be the most appropriate value here (although it would be consistent with previous versions of haven).
What do you think?