### PR TITLE
597 zap label examples

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@
 * The buglet fixed in 2.4.1 when combining `labelled()` with identical labels
 has been fixed in `labelled_spss()` (@gorcha, #599).
 
+* Examples in `zap_label()` now demonstrate removing the label attribute (@jmbarbone, #597)
+
 # haven 2.4.1
 
 * Fix buglet when combining `labelled()` with identical labels.

--- a/R/zap_label.R
+++ b/R/zap_label.R
@@ -10,18 +10,19 @@
 #' @family zappers
 #' @export
 #' @examples
-#' x1 <- labelled(1:5, c(good = 1, bad = 5))
+#' x1 <- labelled(1:5, c(good = 1, bad = 5), label = "rating")
 #' x1
 #' zap_label(x1)
 #'
-#' x2 <- labelled_spss(c(1:4, 9), c(good = 1, bad = 5), na_values = 9)
+#' x2 <- labelled_spss(c(1:4, 9), label = "rating", na_values = 9)
 #' x2
 #' zap_label(x2)
 #'
 #' # zap_label also works with data frames
 #' df <- tibble::tibble(x1, x2)
-#' df
-#' zap_label(df)
+#' lapply(df, identity)         # label not shown in data.frame print
+#' zdf <- zap_label(df)
+#' lapply(zdf, identity)        # label removed from each column
 zap_label <- function(x) {
   UseMethod("zap_label")
 }

--- a/man/zap_label.Rd
+++ b/man/zap_label.Rd
@@ -17,18 +17,19 @@ This function removes variable labels; use \code{\link[=zap_labels]{zap_labels()
 labels.
 }
 \examples{
-x1 <- labelled(1:5, c(good = 1, bad = 5))
+x1 <- labelled(1:5, c(good = 1, bad = 5), label = "rating")
 x1
 zap_label(x1)
 
-x2 <- labelled_spss(c(1:4, 9), c(good = 1, bad = 5), na_values = 9)
+x2 <- labelled_spss(c(1:4, 9), label = "rating", na_values = 9)
 x2
 zap_label(x2)
 
 # zap_label also works with data frames
 df <- tibble::tibble(x1, x2)
-df
-zap_label(df)
+lapply(df, identity)         # label not shown in data.frame print
+zdf <- zap_label(df)
+lapply(zdf, identity)        # label removed from each column
 }
 \seealso{
 Other zappers: 


### PR DESCRIPTION
Resolves #597 

* Adds `label` to `x1`
* Removes `labels` for `x2` to keep it a simple one-liner and to include an example that doesn't use `labels`
* Changes `zap_label.data.frame()` a bit more because the `label` attribute isn't shown during the `data.frame` `print` -- not sure if it's the best or if `zdf[[1]]` and `zdf[[2]]` are more simple