### PR TITLE
Add support for writing SPSS user missing values to integer vectors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # haven (development version)
 
+* `write_sav()` successfully writes user missing values and ranges for
+  `labelled()` integer vectors (@gorcha, #596).
+
 # haven 2.4.3
 
 * Fix build failure on Solaris.

--- a/src/DfWriter.cpp
+++ b/src/DfWriter.cpp
@@ -269,8 +269,6 @@ public:
 
     if (Rf_inherits(x, "haven_labelled_spss")) {
       SEXP na_range = x.attr("na_range");
-      // We have to allow for both REAL and INTEGER here, since na_range cannot
-      // be cast to the vector type
       if (TYPEOF(na_range) == REALSXP && Rf_length(na_range) == 2) {
         readstat_variable_add_missing_double_range(var, REAL(na_range)[0], REAL(na_range)[1]);
       } else if (TYPEOF(na_range) == INTSXP && Rf_length(na_range) == 2) {
@@ -317,8 +315,6 @@ public:
 
     if (Rf_inherits(x, "haven_labelled_spss")) {
       SEXP na_range = x.attr("na_range");
-      // We have to allow for both REAL and INTEGER here, since na_range cannot
-      // be cast to the vector type
       if (TYPEOF(na_range) == REALSXP && Rf_length(na_range) == 2) {
         readstat_variable_add_missing_double_range(var, REAL(na_range)[0], REAL(na_range)[1]);
       } else if (TYPEOF(na_range) == INTSXP && Rf_length(na_range) == 2) {

--- a/src/DfWriter.cpp
+++ b/src/DfWriter.cpp
@@ -266,6 +266,25 @@ public:
     readstat_variable_set_label_set(var, labelSet);
     readstat_variable_set_measure(var, measureType(x));
     readstat_variable_set_display_width(var, displayWidth(x));
+
+    if (Rf_inherits(x, "haven_labelled_spss")) {
+      SEXP na_range = x.attr("na_range");
+      // We have to allow for both REAL and INTEGER here, since na_range cannot
+      // be cast to the vector type
+      if (TYPEOF(na_range) == REALSXP && Rf_length(na_range) == 2) {
+        readstat_variable_add_missing_double_range(var, REAL(na_range)[0], REAL(na_range)[1]);
+      } else if (TYPEOF(na_range) == INTSXP && Rf_length(na_range) == 2) {
+        readstat_variable_add_missing_double_range(var, INTEGER(na_range)[0], INTEGER(na_range)[1]);
+      }
+
+      SEXP na_values = x.attr("na_values");
+      if (TYPEOF(na_values) == INTSXP) {
+        int n = Rf_length(na_values);
+        for (int i = 0; i < n; ++i) {
+          readstat_variable_add_missing_double_value(var, INTEGER(na_values)[i]);
+        }
+      }
+    }
     return readstat_validate_variable(writer_, var);
   }
 
@@ -298,8 +317,12 @@ public:
 
     if (Rf_inherits(x, "haven_labelled_spss")) {
       SEXP na_range = x.attr("na_range");
+      // We have to allow for both REAL and INTEGER here, since na_range cannot
+      // be cast to the vector type
       if (TYPEOF(na_range) == REALSXP && Rf_length(na_range) == 2) {
         readstat_variable_add_missing_double_range(var, REAL(na_range)[0], REAL(na_range)[1]);
+      } else if (TYPEOF(na_range) == INTSXP && Rf_length(na_range) == 2) {
+        readstat_variable_add_missing_double_range(var, INTEGER(na_range)[0], INTEGER(na_range)[1]);
       }
 
       SEXP na_values = x.attr("na_values");

--- a/src/readstat/spss/readstat_sav_write.c
+++ b/src/readstat/spss/readstat_sav_write.c
@@ -243,7 +243,7 @@ static int sav_n_missing_string_values(readstat_variable_t *r_variable) {
 
 static readstat_error_t sav_n_missing_values(int *out_n_missing_values, readstat_variable_t *r_variable) {
     int n_missing_values = 0;
-    if (r_variable->type == READSTAT_TYPE_DOUBLE) {
+    if (readstat_variable_get_type_class(r_variable) == READSTAT_TYPE_CLASS_NUMERIC) {
         n_missing_values = sav_n_missing_double_values(r_variable);
     } else if (readstat_variable_get_storage_width(r_variable) <= 8) {
         n_missing_values = sav_n_missing_string_values(r_variable);
@@ -344,7 +344,7 @@ cleanup:
 }
 
 static readstat_error_t sav_emit_variable_missing_values(readstat_writer_t *writer, readstat_variable_t *r_variable) {
-    if (r_variable->type == READSTAT_TYPE_DOUBLE) {
+    if (readstat_variable_get_type_class(r_variable) == READSTAT_TYPE_CLASS_NUMERIC) {
         return sav_emit_variable_missing_double_values(writer, r_variable);
     } else if (readstat_variable_get_storage_width(r_variable) <= 8) {
         return sav_emit_variable_missing_string_values(writer, r_variable);

--- a/tests/testthat/test-haven-spss.R
+++ b/tests/testthat/test-haven-spss.R
@@ -210,13 +210,7 @@ test_that("labelleds are round tripped", {
 test_that("spss labelleds are round tripped", {
   df <- tibble(
     x = labelled_spss(
-      c(1, 2, 1, 9),
-      labels = c(no = 1, yes = 2, unknown = 9),
-      na_values = 9,
-      na_range = c(80, 90)
-    ),
-    x_int = labelled_spss(
-      c(1L, 2L, 1L, 9L),
+      c(1, 2, 1, 9, 80, 85, 90),
       labels = c(no = 1, yes = 2, unknown = 9),
       na_values = 9,
       na_range = c(80, 90)
@@ -228,17 +222,35 @@ test_that("spss labelleds are round tripped", {
 
   df2 <- read_sav(path)
   expect_s3_class(df2$x, "haven_labelled")
-  expect_equal(as.double(df2$x), c(1, 2, 1, NA))
-  expect_s3_class(df2$x_int, "haven_labelled")
-  expect_equal(as.integer(df2$x_int), c(1, 2, 1, NA))
+  expect_equal(as.double(df2$x), c(1, 2, 1, NA, NA, NA, NA))
 
   df3 <- read_sav(path, user_na = TRUE)
   expect_s3_class(df3$x, "haven_labelled_spss")
   expect_equal(attr(df3$x, "na_values"), attr(df$x, "na_values"))
   expect_equal(attr(df3$x, "na_range"), attr(df$x, "na_range"))
-  expect_s3_class(df3$x_int, "haven_labelled_spss")
-  expect_equal(attr(df3$x_int, "na_values"), attr(df$x_int, "na_values"))
-  expect_equal(attr(df3$x_int, "na_range"), attr(df$x_int, "na_range"))
+})
+
+test_that("spss integer labelleds are round tripped", {
+  df <- tibble(
+    x = labelled_spss(
+      c(1L, 2L, 1L, 9L, 80L, 85L, 90L),
+      labels = c(no = 1, yes = 2, unknown = 9),
+      na_values = 9,
+      na_range = c(80, 90)
+    )
+  )
+
+  path <- tempfile()
+  write_sav(df, path)
+
+  df2 <- read_sav(path)
+  expect_s3_class(df2$x, "haven_labelled")
+  expect_equal(as.integer(df2$x), c(1, 2, 1, NA, NA, NA, NA))
+
+  df3 <- read_sav(path, user_na = TRUE)
+  expect_s3_class(df3$x, "haven_labelled_spss")
+  expect_equal(attr(df3$x, "na_values"), attr(df$x, "na_values"))
+  expect_equal(attr(df3$x, "na_range"), attr(df$x, "na_range"))
 })
 
 test_that("spss string labelleds are round tripped", {

--- a/tests/testthat/test-haven-spss.R
+++ b/tests/testthat/test-haven-spss.R
@@ -214,6 +214,12 @@ test_that("spss labelleds are round tripped", {
       labels = c(no = 1, yes = 2, unknown = 9),
       na_values = 9,
       na_range = c(80, 90)
+    ),
+    x_int = labelled_spss(
+      c(1L, 2L, 1L, 9L),
+      labels = c(no = 1, yes = 2, unknown = 9),
+      na_values = 9,
+      na_range = c(80, 90)
     )
   )
 
@@ -223,11 +229,16 @@ test_that("spss labelleds are round tripped", {
   df2 <- read_sav(path)
   expect_s3_class(df2$x, "haven_labelled")
   expect_equal(as.double(df2$x), c(1, 2, 1, NA))
+  expect_s3_class(df2$x_int, "haven_labelled")
+  expect_equal(as.integer(df2$x_int), c(1, 2, 1, NA))
 
   df3 <- read_sav(path, user_na = TRUE)
   expect_s3_class(df3$x, "haven_labelled_spss")
   expect_equal(attr(df3$x, "na_values"), attr(df$x, "na_values"))
   expect_equal(attr(df3$x, "na_range"), attr(df$x, "na_range"))
+  expect_s3_class(df3$x_int, "haven_labelled_spss")
+  expect_equal(attr(df3$x_int, "na_values"), attr(df$x_int, "na_values"))
+  expect_equal(attr(df3$x_int, "na_range"), attr(df$x_int, "na_range"))
 })
 
 test_that("spss string labelleds are round tripped", {

--- a/tests/testthat/test-haven-spss.R
+++ b/tests/testthat/test-haven-spss.R
@@ -253,6 +253,28 @@ test_that("spss integer labelleds are round tripped", {
   expect_equal(attr(df3$x, "na_range"), attr(df$x, "na_range"))
 })
 
+
+test_that("na_range roundtrips successfully with mismatched type", {
+  x_vec = 1:10
+  x_na = c(1, 10)
+  df <- tibble(
+    x_int_int   = labelled_spss(as.integer(x_vec), na_range = as.integer(x_na)),
+    x_int_real  = labelled_spss(as.integer(x_vec), na_range = as.numeric(x_na)),
+    x_real_real = labelled_spss(as.numeric(x_vec), na_range = as.numeric(x_na)),
+    x_real_int  = labelled_spss(as.numeric(x_vec), na_range = as.integer(x_na))
+  )
+
+  path <- tempfile()
+  write_sav(df, path)
+  df2 <- read_sav(path, user_na = TRUE)
+
+  expect_equal(attr(df2$x_int_int, "na_range"), attr(df$x_int_int, "na_range"))
+  expect_equal(attr(df2$x_int_real, "na_range"), attr(df$x_int_real, "na_range"))
+  expect_equal(attr(df2$x_real_real, "na_range"), attr(df$x_real_real, "na_range"))
+  expect_equal(attr(df2$x_real_int, "na_range"), attr(df$x_real_int, "na_range"))
+})
+
+
 test_that("spss string labelleds are round tripped", {
   df <- tibble(
     x = labelled_spss(


### PR DESCRIPTION
This PR fixes #596, adding write support for SPSS user missing values for integers as well as doubles.

This includes a minor change to the readstat SAV writing code - this change has been made upstream and will come through in the next readstat release (see WizardMac/ReadStat#251).

One thing to note is that we need to allow for either integer or real values in the na_range attribute if the main vector is either type, since we can't cast na_range to the vector type in labelled_spss().
Although na_values are cast to the type of the vector in labelled_spss(), na_range has to allow numeric vectors so that Inf/-Inf can be represented (the equivalent of SPSS HI and LO placeholders).