### PR TITLE
Add support for writing data set labels to `write_xpt()` (#562)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # haven (development version)
 
+* `write_xpt()` can now write dataset labels with the `label` argument, 
+  which defaults to the `label` attribute of the input data frame, if present
+  (#562).
+
 * The `compress` argument for `write_sav()` now supports all 3 SPSS compression
   modes specified as a character string - "byte", "none" and "zsav" (#614).
   `TRUE` and `FALSE` can be used for backwards compatibility, and correspond to

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,7 @@
 # haven (development version)
 
-* `write_xpt()` can now write dataset labels with the `label` argument, 
-  which defaults to the `label` attribute of the input data frame, if present
-  (#562).
+* `write_xpt()` can now write dataset labels with the `label` argument,  which
+  defaults to the `label` attribute of the input data frame, if present (#562).
 
 * The `compress` argument for `write_sav()` now supports all 3 SPSS compression
   modes specified as a character string - "byte", "none" and "zsav" (#614).

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -52,6 +52,6 @@ write_sas_ <- function(data, path) {
   invisible(.Call(`_haven_write_sas_`, data, path))
 }
 
-write_xpt_ <- function(data, path, version, name) {
-  invisible(.Call(`_haven_write_xpt_`, data, path, version, name))
+write_xpt_ <- function(data, path, version, name, label) {
+  invisible(.Call(`_haven_write_xpt_`, data, path, version, name, label))
 }

--- a/R/haven-sas.R
+++ b/R/haven-sas.R
@@ -112,7 +112,12 @@ read_xpt <- function(file, col_select = NULL, skip = 0, n_max = Inf, .name_repai
 #' @param name Member name to record in file. Defaults to file name sans
 #'   extension. Must be <= 8 characters for version 5, and <= 32 characters
 #'   for version 8.
-write_xpt <- function(data, path, version = 8, name = NULL) {
+#' @param label Dataset label to use, or `NULL`. Defaults to the value stored in
+#'   the "label" attribute of `data`.
+#'
+#'   Note that although SAS itself supports data set labels up to 256 characters
+#'   long, data set labels in SAS transport files must be <= 40 characters.
+write_xpt <- function(data, path, version = 8, name = NULL, label = attr(data, "label")) {
   stopifnot(version %in% c(5, 8))
 
   if (is.null(name)) {
@@ -125,7 +130,8 @@ write_xpt <- function(data, path, version = 8, name = NULL) {
     data,
     normalizePath(path, mustWork = FALSE),
     version = version,
-    name = name
+    name = name,
+    label = label
   )
   invisible(data)
 }
@@ -151,5 +157,15 @@ validate_xpt_name <- function(name, version) {
     }
   }
   name
+}
+
+validate_xpt_label <- function(label) {
+  if (!is.null(label)) {
+    stopifnot(is.character(label), length(label) == 1)
+
+    if (nchar(label) > 40) {
+      stop("`label` must be 40 characters or fewer", call. = FALSE)
+    }
+  }
 }
 

--- a/R/haven-sas.R
+++ b/R/haven-sas.R
@@ -87,6 +87,9 @@ write_sas <- function(data, path) {
 #'   Variable labels are stored in the "label" attribute of each variable.
 #'   It is not printed on the console, but the RStudio viewer will show it.
 #'
+#'   If a dataset label is defined, it will be stored in the "label" attribute
+#'   of the tibble.
+#'
 #'   `write_xpt()` returns the input `data` invisibly.
 #' @export
 #' @examples
@@ -115,8 +118,8 @@ read_xpt <- function(file, col_select = NULL, skip = 0, n_max = Inf, .name_repai
 #' @param label Dataset label to use, or `NULL`. Defaults to the value stored in
 #'   the "label" attribute of `data`.
 #'
-#'   Note that although SAS itself supports data set labels up to 256 characters
-#'   long, data set labels in SAS transport files must be <= 40 characters.
+#'   Note that although SAS itself supports dataset labels up to 256 characters
+#'   long, dataset labels in SAS transport files must be <= 40 characters.
 write_xpt <- function(data, path, version = 8, name = NULL, label = attr(data, "label")) {
   stopifnot(version %in% c(5, 8))
 

--- a/man/read_xpt.Rd
+++ b/man/read_xpt.Rd
@@ -13,7 +13,7 @@ read_xpt(
   .name_repair = "unique"
 )
 
-write_xpt(data, path, version = 8, name = NULL)
+write_xpt(data, path, version = 8, name = NULL, label = attr(data, "label"))
 }
 \arguments{
 \item{file}{Either a path to a file, a connection, or literal data
@@ -65,6 +65,12 @@ to enforce them.}
 \item{name}{Member name to record in file. Defaults to file name sans
 extension. Must be <= 8 characters for version 5, and <= 32 characters
 for version 8.}
+
+\item{label}{Dataset label to use, or \code{NULL}. Defaults to the value stored in
+the "label" attribute of \code{data}.
+
+Note that although SAS itself supports data set labels up to 256 characters
+long, data set labels in SAS transport files must be <= 40 characters.}
 }
 \value{
 A tibble, data frame variant with nice defaults.

--- a/man/read_xpt.Rd
+++ b/man/read_xpt.Rd
@@ -69,14 +69,17 @@ for version 8.}
 \item{label}{Dataset label to use, or \code{NULL}. Defaults to the value stored in
 the "label" attribute of \code{data}.
 
-Note that although SAS itself supports data set labels up to 256 characters
-long, data set labels in SAS transport files must be <= 40 characters.}
+Note that although SAS itself supports dataset labels up to 256 characters
+long, dataset labels in SAS transport files must be <= 40 characters.}
 }
 \value{
 A tibble, data frame variant with nice defaults.
 
 Variable labels are stored in the "label" attribute of each variable.
 It is not printed on the console, but the RStudio viewer will show it.
+
+If a dataset label is defined, it will be stored in the "label" attribute
+of the tibble.
 
 \code{write_xpt()} returns the input \code{data} invisibly.
 }

--- a/src/DfWriter.cpp
+++ b/src/DfWriter.cpp
@@ -436,9 +436,10 @@ void write_sas_(cpp11::list data, cpp11::strings path) {
 }
 
 [[cpp11::register]]
-void write_xpt_(cpp11::list data, cpp11::strings path, int version, std::string name) {
+void write_xpt_(cpp11::list data, cpp11::strings path, int version, std::string name, cpp11::sexp label) {
   Writer writer(HAVEN_XPT, data, path);
   writer.setVersion(version);
   writer.setName(name);
+  writer.setFileLabel(label);
   writer.write();
 }

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -99,10 +99,10 @@ extern "C" SEXP _haven_write_sas_(SEXP data, SEXP path) {
   END_CPP11
 }
 // DfWriter.cpp
-void write_xpt_(cpp11::list data, cpp11::strings path, int version, std::string name);
-extern "C" SEXP _haven_write_xpt_(SEXP data, SEXP path, SEXP version, SEXP name) {
+void write_xpt_(cpp11::list data, cpp11::strings path, int version, std::string name, cpp11::sexp label);
+extern "C" SEXP _haven_write_xpt_(SEXP data, SEXP path, SEXP version, SEXP name, SEXP label) {
   BEGIN_CPP11
-    write_xpt_(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(data), cpp11::as_cpp<cpp11::decay_t<cpp11::strings>>(path), cpp11::as_cpp<cpp11::decay_t<int>>(version), cpp11::as_cpp<cpp11::decay_t<std::string>>(name));
+    write_xpt_(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(data), cpp11::as_cpp<cpp11::decay_t<cpp11::strings>>(path), cpp11::as_cpp<cpp11::decay_t<int>>(version), cpp11::as_cpp<cpp11::decay_t<std::string>>(name), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(label));
     return R_NilValue;
   END_CPP11
 }
@@ -122,7 +122,7 @@ extern SEXP _haven_df_parse_xpt_raw(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP _haven_write_dta_(SEXP, SEXP, SEXP, SEXP);
 extern SEXP _haven_write_sas_(SEXP, SEXP);
 extern SEXP _haven_write_sav_(SEXP, SEXP, SEXP);
-extern SEXP _haven_write_xpt_(SEXP, SEXP, SEXP, SEXP);
+extern SEXP _haven_write_xpt_(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP is_tagged_na_(SEXP, SEXP);
 extern SEXP na_tag_(SEXP);
 extern SEXP tagged_na_(SEXP);
@@ -141,7 +141,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_haven_write_dta_",        (DL_FUNC) &_haven_write_dta_,        4},
     {"_haven_write_sas_",        (DL_FUNC) &_haven_write_sas_,        2},
     {"_haven_write_sav_",        (DL_FUNC) &_haven_write_sav_,        3},
-    {"_haven_write_xpt_",        (DL_FUNC) &_haven_write_xpt_,        4},
+    {"_haven_write_xpt_",        (DL_FUNC) &_haven_write_xpt_,        5},
     {"is_tagged_na_",            (DL_FUNC) &is_tagged_na_,            2},
     {"na_tag_",                  (DL_FUNC) &na_tag_,                  1},
     {"tagged_na_",               (DL_FUNC) &tagged_na_,               1},

--- a/tests/testthat/test-haven-sas.R
+++ b/tests/testthat/test-haven-sas.R
@@ -232,3 +232,14 @@ test_that("invalid files generate informative errors", {
     write_xpt(mtcars, file.path(tempdir(), " temp.xpt"))
   })
 })
+
+test_that("can roundtrip file labels", {
+  df <- tibble(x = 1)
+  expect_null(attr(roundtrip_xpt(df), "label"))
+  expect_equal(attr(roundtrip_xpt(df, label = "abcd"), "label"), "abcd")
+
+  attr(df, "label") <- "abc"
+  expect_equal(attr(roundtrip_xpt(df), "label"), "abc")
+  expect_equal(attr(roundtrip_xpt(df, label = "abcd"), "label"), "abcd")
+  expect_null(attr(roundtrip_xpt(df, label = NULL), "label"))
+})


### PR DESCRIPTION
This adds support for writing dataset labels for SAS transport files, closing #562.
Mostly copied and modified from #452.