### PR TITLE
Preserve attributes in output timezone conversion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # haven (development version)
 
+* Fix bug in output timezone conversion that was causing variable labels and
+  other variable attributes to disappear (#624).
+
 * The `compress` argument for `write_sav()` now supports all 3 SPSS compression
   modes specified as a character string - "byte", "none" and "zsav" (#614).
   `TRUE` and `FALSE` can be used for backwards compatibility, and correspond to

--- a/R/utils.R
+++ b/R/utils.R
@@ -12,7 +12,11 @@ force_utc <- function(x) {
   if (identical(attr(x, "tzone"), "UTC")) {
     x
   } else {
-    as.POSIXct(format(x, usetz = FALSE), tz = "UTC", format = "%Y-%m-%d %H:%M:%S")
+    x_attr <- attributes(x)
+    x <- as.POSIXct(format(x, usetz = FALSE), tz = "UTC", format = "%Y-%m-%d %H:%M:%S")
+    attr_miss <- setdiff(names(x_attr), names(attributes(x)))
+    attributes(x)[attr_miss] <- x_attr[attr_miss]
+    x
   }
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,7 +14,7 @@ force_utc <- function(x) {
   } else {
     x_attr <- attributes(x)
     x <- as.POSIXct(format(x, usetz = FALSE), tz = "UTC", format = "%Y-%m-%d %H:%M:%S")
-    attr_miss <- setdiff(names(x_attr), names(attributes(x)))
+    attr_miss <- setdiff(names(x_attr), c(names(attributes(x)), "names"))
     attributes(x)[attr_miss] <- x_attr[attr_miss]
     x
   }

--- a/tests/testthat/test-force_utc.R
+++ b/tests/testthat/test-force_utc.R
@@ -1,0 +1,13 @@
+test_that("force_utc doesn't preserve attributes we don't want", {
+  x_ct <- as.POSIXct("2010-01-01 09:00", tz = "Pacific/Auckland")
+  x_ct_forced <- force_utc(x_ct)
+  expect_s3_class(x_ct_forced, "POSIXct")
+  expect_null(attr(x_ct_forced, "names"))
+  expect_equal(attr(x_ct_forced, "tzone"), "UTC")
+
+  x_lt <- as.POSIXlt("2010-01-01 09:00", tz = "Pacific/Auckland")
+  x_lt_forced <- force_utc(x_lt)
+  expect_s3_class(x_lt_forced, "POSIXct")
+  expect_null(attr(x_lt_forced, "names"))
+  expect_equal(attr(x_lt_forced, "tzone"), "UTC")
+})

--- a/tests/testthat/test-haven-sas.R
+++ b/tests/testthat/test-haven-sas.R
@@ -176,11 +176,17 @@ test_that("can write labelled with NULL labels", {
 
 test_that("can roundtrip date times", {
   x1 <- c(as.Date("2010-01-01"), NA)
-  x2 <- as.POSIXct(x1)
-  attr(x2, "tzone") <- "UTC"
-
   expect_equal(roundtrip_var(x1, "sas"), x1)
-  expect_equal(roundtrip_var(x2, "sas"), x2)
+
+  # converted to same time in UTC
+  x2 <- as.POSIXct("2010-01-01 09:00", tz = "Pacific/Auckland")
+  expect_equal(
+    roundtrip_var(x2, "sas"),
+    as.POSIXct("2010-01-01 09:00", tz = "UTC")
+  )
+
+  attr(x2, "label") <- "abc"
+  expect_equal(attr(roundtrip_var(x2, "sas"), "label"), "abc")
 })
 
 test_that("can roundtrip format attribute", {

--- a/tests/testthat/test-haven-spss.R
+++ b/tests/testthat/test-haven-spss.R
@@ -166,11 +166,17 @@ test_that("can roundtrip missing values (as much as possible)", {
 
 test_that("can roundtrip date times", {
   x1 <- c(as.Date("2010-01-01"), NA)
-  x2 <- as.POSIXct(x1)
-  attr(x2, "tzone") <- "UTC"
-
   expect_equal(roundtrip_var(x1, "sav"), x1)
-  expect_equal(roundtrip_var(x2, "sav"), x2)
+
+  # converted to same time in UTC
+  x2 <- as.POSIXct("2010-01-01 09:00", tz = "Pacific/Auckland")
+  expect_equal(
+    roundtrip_var(x2, "sav"),
+    as.POSIXct("2010-01-01 09:00", tz = "UTC")
+  )
+
+  attr(x2, "label") <- "abc"
+  expect_equal(attr(roundtrip_var(x2, "sav"), "label"), "abc")
 })
 
 test_that("can roundtrip times", {

--- a/tests/testthat/test-haven-stata.R
+++ b/tests/testthat/test-haven-stata.R
@@ -114,6 +114,9 @@ test_that("can roundtrip date times", {
     roundtrip_var(x2, "dta"),
     as.POSIXct("2010-01-01 09:00", tz = "UTC")
   )
+
+  attr(x2, "label") <- "abc"
+  expect_equal(attr(roundtrip_var(x2, "dta"), "label"), "abc")
 })
 
 test_that("can roundtrip tagged NAs", {


### PR DESCRIPTION
The shared function that converts timezones to UTC in the `write_*` functions uses `as.POSIXct`, which drops all attributes (variable label etc.) (#624).

This PR preserves the attributes. I've also expanded the date time tests slightly so the datetime roundtrip performs the same tests for all file types.