### PR TITLE
Allow for POSIX dates with no time component (e.g. "2010-01-01") in output timezone conversion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # haven (development version)
 
+* POSIXct and POSIXlt values with no time component (e.g. "2010-01-01") were
+  being converted to `NA` when attempting to convert the output timezone to UTC.
+  These now output successfully (#634).
+
 * Fix bug in output timezone conversion that was causing variable labels and
   other variable attributes to disappear (#624).
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -13,8 +13,8 @@ force_utc <- function(x) {
     x
   } else {
     x_attr <- attributes(x)
-    x <- as.POSIXct(format(x, usetz = FALSE, format = "%Y-%m-%d %H:%M:%S"),
-                    tz = "UTC", format = "%Y-%m-%d %H:%M:%S")
+    x <- format(x, usetz = FALSE, format = "%Y-%m-%d %H:%M:%S")
+    x <- as.POSIXct(x, tz = "UTC", format = "%Y-%m-%d %H:%M:%S")
     attr_miss <- setdiff(names(x_attr), c(names(attributes(x)), "names"))
     attributes(x)[attr_miss] <- x_attr[attr_miss]
     x

--- a/R/utils.R
+++ b/R/utils.R
@@ -13,7 +13,8 @@ force_utc <- function(x) {
     x
   } else {
     x_attr <- attributes(x)
-    x <- as.POSIXct(format(x, usetz = FALSE), tz = "UTC", tryFormats = c("%Y-%m-%d %H:%M:%S", "%Y-%m-%d"))
+    x <- as.POSIXct(format(x, usetz = FALSE, format = "%Y-%m-%d %H:%M:%S"),
+                    tz = "UTC", format = "%Y-%m-%d %H:%M:%S")
     attr_miss <- setdiff(names(x_attr), c(names(attributes(x)), "names"))
     attributes(x)[attr_miss] <- x_attr[attr_miss]
     x

--- a/R/utils.R
+++ b/R/utils.R
@@ -13,7 +13,7 @@ force_utc <- function(x) {
     x
   } else {
     x_attr <- attributes(x)
-    x <- as.POSIXct(format(x, usetz = FALSE), tz = "UTC", format = "%Y-%m-%d %H:%M:%S")
+    x <- as.POSIXct(format(x, usetz = FALSE), tz = "UTC", tryFormats = c("%Y-%m-%d %H:%M:%S", "%Y-%m-%d"))
     attr_miss <- setdiff(names(x_attr), c(names(attributes(x)), "names"))
     attributes(x)[attr_miss] <- x_attr[attr_miss]
     x

--- a/tests/testthat/test-force_utc.R
+++ b/tests/testthat/test-force_utc.R
@@ -11,3 +11,31 @@ test_that("force_utc doesn't preserve attributes we don't want", {
   expect_null(attr(x_lt_forced, "names"))
   expect_equal(attr(x_lt_forced, "tzone"), "UTC")
 })
+
+test_that("force_utc works for dates as well as date times", {
+  x_ct <- as.POSIXct("2010-01-01", tz = "Pacific/Auckland")
+  x_ct_forced <- force_utc(x_ct)
+  expect_s3_class(x_ct_forced, "POSIXct")
+  expect_equal(attr(x_ct_forced, "tzone"), "UTC")
+  expect_equal(format(x_ct, "%Y-%m-%d"), format(x_ct_forced, "%Y-%m-%d"))
+
+  x_lt <- as.POSIXlt("2010-01-01", tz = "Pacific/Auckland")
+  x_lt_forced <- force_utc(x_lt)
+  expect_s3_class(x_lt_forced, "POSIXct")
+  expect_equal(attr(x_lt_forced, "tzone"), "UTC")
+  expect_equal(format(x_lt, "%Y-%m-%d"), format(x_lt_forced, "%Y-%m-%d"))
+})
+
+test_that("objects with UTC tz pass through unchanged", {
+  x_ct <- as.POSIXct("2010-01-01 09:00", tz = "UTC")
+  expect_identical(x_ct, force_utc(x_ct))
+
+  x_lt <- as.POSIXlt("2010-01-01 09:00", tz = "UTC")
+  expect_identical(x_lt, force_utc(x_lt))
+
+  x_ct <- as.POSIXct("2010-01-01", tz = "UTC")
+  expect_identical(x_ct, force_utc(x_ct))
+
+  x_lt <- as.POSIXlt("2010-01-01", tz = "UTC")
+  expect_identical(x_lt, force_utc(x_lt))
+})


### PR DESCRIPTION
The function that converts timezones to UTC in the `write_*` functions uses `as.POSIXct` with the format string `"%Y-%m-%d %H:%M:%S"`, which forces POSIX dates without a time component to `NA` (#634).

This PR allows for both date time (`"%Y-%m-%d %H:%M:%S"`) and date (`"%Y-%m-%d"`) format strings.