### PR TITLE
Add `user_na` argument to `zap_labels()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,5 +48,5 @@ VignetteBuilder:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 SystemRequirements: GNU make, C++11, zlib

--- a/NEWS.md
+++ b/NEWS.md
@@ -328,7 +328,7 @@ This also brings with it a deprecation: `cols_only` in `read_sas()` has been dep
   user missing values from SPSS. These can either be a set of distinct
   values, or for numeric vectors, a range. `zap_labels()` strips labels,
   and replaces user-defined missing values with `NA`. New `zap_missing()`
-  just replaces user-defined missing vlaues with `NA`. 
+  just replaces user-defined missing values with `NA`. 
   
     `labelled_spss()` is potentially dangerous to work with in R because
     base functions don't know about `labelled_spss()` functions so will 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # haven (development version)
 
+* `zap_labels()` gains a `user_na` argument to control whether user-defined
+  missing values are converted to `NA` or left as is (#638).
+
 * POSIXct and POSIXlt values with no time component (e.g. "2010-01-01") were
   being converted to `NA` when attempting to convert the output timezone to UTC.
   These now output successfully (#634).

--- a/R/zap_labels.R
+++ b/R/zap_labels.R
@@ -5,9 +5,14 @@
 #' want to simply drop all `labels` from a data frame.
 #'
 #' Zapping labels from [labelled_spss()] also removes user-defined missing
-#' values, replacing with standard `NA`s.
+#' values by default, replacing with standard `NA`s. Use the `user_na` argument
+#' to override this behaviour.
 #'
 #' @param x A vector or data frame
+#' @param user_na If `FALSE`, the default, `zap_labels()` will convert
+#'   [labelled_spss()] user-defined missing values to `NA`. If `TRUE` they
+#'   will be treated like normal values.
+#' @param ... Other arguments passed down to method.
 #' @family zappers
 #' @seealso [zap_label()] to remove variable labels.
 #' @export
@@ -20,30 +25,36 @@
 #' x2
 #' zap_labels(x2)
 #'
+#' # Keep the user defined missing values
+#' zap_labels(x2, user_na = TRUE)
+#'
 #' # zap_labels also works with data frames
 #' df <- tibble::tibble(x1, x2)
 #' df
 #' zap_labels(df)
-zap_labels <- function(x) {
+zap_labels <- function(x, ...) {
   UseMethod("zap_labels")
 }
 
 #' @export
-zap_labels.default <- function(x) {
+zap_labels.default <- function(x, ...) {
   x
 }
 
 #' @export
-zap_labels.haven_labelled <- function(x) {
+zap_labels.haven_labelled <- function(x, ...) {
   attr(x, "labels") <- NULL
   class(x) <- NULL
 
   x
 }
 
+#' @rdname zap_labels
 #' @export
-zap_labels.haven_labelled_spss <- function(x) {
-  x[is.na(x)] <- NA
+zap_labels.haven_labelled_spss <- function(x, user_na = FALSE, ...) {
+  if (isFALSE(user_na)) {
+    x[is.na(x)] <- NA
+  }
 
   attr(x, "labels") <- NULL
   attr(x, "na_values") <- NULL
@@ -54,8 +65,9 @@ zap_labels.haven_labelled_spss <- function(x) {
 }
 
 
+#' @rdname zap_labels
 #' @export
-zap_labels.data.frame <- function(x) {
-  x[] <- lapply(x, zap_labels)
+zap_labels.data.frame <- function(x, user_na = FALSE, ...) {
+  x[] <- lapply(x, zap_labels, user_na = user_na, ...)
   x
 }

--- a/man/read_dta.Rd
+++ b/man/read_dta.Rd
@@ -36,9 +36,9 @@ be automatically uncompressed. Files starting with \verb{http://},
 downloaded. Remote gz files can also be automatically downloaded and
 decompressed.
 
-Literal data is most useful for examples and tests. It must contain at
-least one new line to be recognised as data (instead of a path) or be a
-vector of greater than length 1.
+Literal data is most useful for examples and tests. To be recognised as a
+path, it must be wrapped with \code{I()}, be a string containing at least one
+new line, or be a vector containing at least one string with a new line.
 
 Using a value of \code{\link[readr:clipboard]{clipboard()}} will read from the system clipboard.}
 

--- a/man/read_spss.Rd
+++ b/man/read_spss.Rd
@@ -47,9 +47,9 @@ be automatically uncompressed. Files starting with \verb{http://},
 downloaded. Remote gz files can also be automatically downloaded and
 decompressed.
 
-Literal data is most useful for examples and tests. It must contain at
-least one new line to be recognised as data (instead of a path) or be a
-vector of greater than length 1.
+Literal data is most useful for examples and tests. To be recognised as a
+path, it must be wrapped with \code{I()}, be a string containing at least one
+new line, or be a vector containing at least one string with a new line.
 
 Using a value of \code{\link[readr:clipboard]{clipboard()}} will read from the system clipboard.}
 

--- a/man/read_xpt.Rd
+++ b/man/read_xpt.Rd
@@ -25,9 +25,9 @@ be automatically uncompressed. Files starting with \verb{http://},
 downloaded. Remote gz files can also be automatically downloaded and
 decompressed.
 
-Literal data is most useful for examples and tests. It must contain at
-least one new line to be recognised as data (instead of a path) or be a
-vector of greater than length 1.
+Literal data is most useful for examples and tests. To be recognised as a
+path, it must be wrapped with \code{I()}, be a string containing at least one
+new line, or be a vector containing at least one string with a new line.
 
 Using a value of \code{\link[readr:clipboard]{clipboard()}} will read from the system clipboard.}
 

--- a/man/zap_labels.Rd
+++ b/man/zap_labels.Rd
@@ -2,19 +2,32 @@
 % Please edit documentation in R/zap_labels.R
 \name{zap_labels}
 \alias{zap_labels}
+\alias{zap_labels.haven_labelled_spss}
+\alias{zap_labels.data.frame}
 \title{Zap value labels}
 \usage{
-zap_labels(x)
+zap_labels(x, ...)
+
+\method{zap_labels}{haven_labelled_spss}(x, user_na = FALSE, ...)
+
+\method{zap_labels}{data.frame}(x, user_na = FALSE, ...)
 }
 \arguments{
 \item{x}{A vector or data frame}
+
+\item{...}{Other arguments passed down to method.}
+
+\item{user_na}{If \code{FALSE}, the default, \code{zap_labels()} will convert
+\code{\link[=labelled_spss]{labelled_spss()}} user-defined missing values to \code{NA}. If \code{TRUE} they
+will be treated like normal values.}
 }
 \description{
 Removes value labels, leaving unlabelled vectors as is. Use this if you
 want to simply drop all \code{labels} from a data frame.
 
 Zapping labels from \code{\link[=labelled_spss]{labelled_spss()}} also removes user-defined missing
-values, replacing with standard \code{NA}s.
+values by default, replacing with standard \code{NA}s. Use the \code{user_na} argument
+to override this behaviour.
 }
 \examples{
 x1 <- labelled(1:5, c(good = 1, bad = 5))
@@ -24,6 +37,9 @@ zap_labels(x1)
 x2 <- labelled_spss(c(1:4, 9), c(good = 1, bad = 5), na_values = 9)
 x2
 zap_labels(x2)
+
+# Keep the user defined missing values
+zap_labels(x2, user_na = TRUE)
 
 # zap_labels also works with data frames
 df <- tibble::tibble(x1, x2)

--- a/tests/testthat/test-zap_labels.R
+++ b/tests/testthat/test-zap_labels.R
@@ -18,3 +18,8 @@ test_that("replaces user-defined missings for spss", {
   x <- labelled_spss(1:5, c(a = 1), na_values = c(2, 4))
   expect_equal(zap_labels(x), c(1, NA, 3, NA, 5))
 })
+
+test_that("keeps user-defined missings for spss if user_na = TRUE", {
+  x <- labelled_spss(1:5, c(a = 1), na_values = c(2, 4))
+  expect_equal(zap_labels(x, user_na = TRUE), 1:5)
+})


### PR DESCRIPTION
This PR adds a `user_na` argument to `zap_labels()` to control treatment of user-defined missing values for `labelled_spss()` vectors (#638).