### PR TITLE
Add anticonf script to check for zlib before compiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ revdep/library.noindex
 revdep/data.sqlite
 .httr-oauth
 .vscode/
+src/Makevars
+configure.log

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,4 +50,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
-SystemRequirements: GNU make, C++11, zlib
+SystemRequirements: GNU make, C++11, zlib: zlib1g-dev (deb), zlib-devel (rpm)

--- a/configure
+++ b/configure
@@ -1,0 +1,74 @@
+# Anticonf (tm) script by Jeroen Ooms (2021)
+# This script will query 'pkg-config' for the required cflags and ldflags.
+# If pkg-config is unavailable or does not find the library, try setting
+# INCLUDE_DIR and LIB_DIR manually via e.g:
+# R CMD INSTALL --configure-vars='INCLUDE_DIR=/.../include LIB_DIR=/.../lib'
+
+# Library settings
+PKG_CONFIG_NAME="zlib"
+PKG_DEB_NAME="zlib1g-dev"
+PKG_RPM_NAME="zlib-devel"
+PKG_CSW_NAME="libz_dev"
+PKG_BREW_NAME="zlib"
+PKG_TEST_HEADER="<zlib.h>"
+PKG_LIBS="-lz"
+PKG_CFLAGS=""
+
+# Support static linking for binary packages on MacOS
+if [ `uname` = "Darwin" ]; then
+PKG_CONFIG_NAME="--static $PKG_CONFIG_NAME"
+fi
+
+# Use pkg-config if available
+if [ "`command -v pkg-config`" ]; then
+  PKGCONFIG_CFLAGS="`pkg-config --cflags --silence-errors ${PKG_CONFIG_NAME}`"
+  PKGCONFIG_LIBS="`pkg-config --libs ${PKG_CONFIG_NAME}`"
+fi
+
+# Note that cflags may be empty in case of success
+if [ "$INCLUDE_DIR" ] || [ "$LIB_DIR" ]; then
+  echo "Found INCLUDE_DIR and/or LIB_DIR!"
+  PKG_CFLAGS="-I$INCLUDE_DIR $PKG_CFLAGS"
+  PKG_LIBS="-L$LIB_DIR $PKG_LIBS"
+elif [ "$PKGCONFIG_CFLAGS" ] || [ "$PKGCONFIG_LIBS" ]; then
+  echo "Found pkg-config cflags and libs!"
+  PKG_CFLAGS=${PKGCONFIG_CFLAGS}
+  PKG_LIBS=${PKGCONFIG_LIBS}
+fi
+
+# For debugging
+echo "Using PKG_CFLAGS=$PKG_CFLAGS"
+echo "Using PKG_LIBS=$PKG_LIBS"
+
+# Find compiler
+CC=`${R_HOME}/bin/R CMD config CC`
+CFLAGS=`${R_HOME}/bin/R CMD config CFLAGS`
+CPPFLAGS=`${R_HOME}/bin/R CMD config CPPFLAGS`
+
+# Test configuration
+echo "#include $PKG_TEST_HEADER" | ${CC} ${CPPFLAGS} ${PKG_CFLAGS} ${CFLAGS} -E -xc - >/dev/null 2>configure.log
+
+# Customize the error
+if [ $? -ne 0 ]; then
+  echo "--------------------------- [ANTICONF] --------------------------------"
+  echo "Configuration failed to find the $PKG_CONFIG_NAME library. Try installing:"
+  echo " * deb: $PKG_DEB_NAME (Debian, Ubuntu, etc)"
+  echo " * rpm: $PKG_RPM_NAME (Fedora, EPEL)"
+  echo " * csw: $PKG_CSW_NAME (Solaris)"
+  echo " * brew: $PKG_BREW_NAME (OSX)"
+  echo "If $PKG_CONFIG_NAME is already installed, check that 'pkg-config' is in your"
+  echo "PATH and PKG_CONFIG_PATH contains a $PKG_CONFIG_NAME.pc file. If pkg-config"
+  echo "is unavailable you can set INCLUDE_DIR and LIB_DIR manually via:"
+  echo "R CMD INSTALL --configure-vars='INCLUDE_DIR=... LIB_DIR=...'"
+  echo "-------------------------- [ERROR MESSAGE] ---------------------------"
+  cat configure.log
+  echo "--------------------------------------------------------------------"
+  exit 1
+fi
+
+# Write to Makevars
+sed -e "s|@cflags@|$PKG_CFLAGS|" -e "s|@libs@|$PKG_LIBS|" src/Makevars.in > src/Makevars
+
+# Success
+exit 0
+

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -6,6 +6,6 @@ SOURCES = $(CFILES) $(CPPFILES)
 # This must be defined identically in Makevars.win
 OBJECTS = $(CFILES:.c=.o) $(CPPFILES:.cpp=.o)
 
-PKG_CFLAGS = -Ireadstat -DHAVE_ZLIB
-PKG_CXXFLAGS = -Ireadstat -DHAVE_ZLIB
-PKG_LIBS = -lz
+PKG_CFLAGS = @cflags@ -Ireadstat -DHAVE_ZLIB
+PKG_CXXFLAGS = @cflags@ -Ireadstat -DHAVE_ZLIB
+PKG_LIBS = @libs@

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,6 +1,11 @@
-include Makevars
+CFILES = $(wildcard *.c readstat/*.c readstat/sas/*.c readstat/spss/*.c readstat/stata/*.c)
+CPPFILES = $(wildcard *.cpp)
 
-# This is also defined in Makevars, but somehow the definition from there is not used
+SOURCES = $(CFILES) $(CPPFILES)
+
 OBJECTS = $(CFILES:.c=.o) $(CPPFILES:.cpp=.o)
+
+PKG_CFLAGS = -Ireadstat -DHAVE_ZLIB
+PKG_CXXFLAGS = -Ireadstat -DHAVE_ZLIB
 
 PKG_LIBS=-lRiconv -lz


### PR DESCRIPTION
This PR adds the anticonf configure script from @jeroen adapted to check for zlib before compiling, closing #656.

Do we need to add Jeroen to the authors to acknowledge the inclusion of the script?