### PR TITLE
Throw a warning when two labelled vectors with conflicting labels are combined

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 * Updated to ReadStat 1.1.8 RC (#650).
 
+* `labelled()` vectors now throw a warning when combining two vectors with
+  conflicting labels (#667).
+
 * `write_dta()` now uses strL when strings are too long to be stored in an str#
   variable (#437). strL is used when strings are longer than 2045 characters by
   default, which matches Stata's behaviour, but this can be reduced with the

--- a/R/labelled.R
+++ b/R/labelled.R
@@ -239,7 +239,7 @@ vec_ptype2.haven_labelled.haven_labelled <- function(x, y, ..., x_arg = "", y_ar
   # Prefer labels from LHS
   x_labels <- vec_cast_named(attr(x, "labels"), data_type, x_arg = x_arg)
   y_labels <- vec_cast_named(attr(y, "labels"), data_type, x_arg = y_arg)
-  labels <- c(x_labels, y_labels[!y_labels %in% x_labels])
+  labels <- combine_labels(x_labels, y_labels, x_arg, y_arg)
 
   # Prefer labels from LHS
   label <- attr(x, "label", exact = TRUE) %||% attr(y, "label", exact = TRUE)

--- a/R/labelled_spss.R
+++ b/R/labelled_spss.R
@@ -143,7 +143,7 @@ vec_ptype2.haven_labelled_spss.haven_labelled_spss <- function(x, y, ..., x_arg 
   # Prefer labels from LHS
   x_labels <- vec_cast_named(attr(x, "labels"), data_type, x_arg = x_arg)
   y_labels <- vec_cast_named(attr(y, "labels"), data_type, x_arg = y_arg)
-  labels <- c(x_labels, y_labels[!y_labels %in% x_labels])
+  labels <- combine_labels(x_labels, y_labels, x_arg, y_arg)
 
   # Prefer labels from LHS
   label <- attr(x, "label", exact = TRUE) %||% attr(y, "label", exact = TRUE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -19,7 +19,7 @@ combine_labels <- function(x_labels, y_labels, x_arg, y_arg) {
     problems <- x_common[names(x_common) != names(y_common)]
     if (length(problems) > 0) {
       problems_msg <- paste(problems[1:min(length(problems), 10)], collapse = ", ")
-      if (length(problems_msg) > 10)
+      if (length(problems) > 10)
         problems_msg <- paste0(problems_msg, ", ...")
 
       warn(c(

--- a/R/utils.R
+++ b/R/utils.R
@@ -8,6 +8,31 @@ vec_cast_named <- function(x, to, ...) {
   stats::setNames(vec_cast(x, to, ...), names(x))
 }
 
+combine_labels <- function(x_labels, y_labels, x_arg, y_arg) {
+  x_common <- x_labels[x_labels %in% y_labels]
+  y_common <- y_labels[y_labels %in% x_labels]
+
+  if (length(x_common) > 0) {
+    x_common <- x_common[order(x_common)]
+    y_common <- y_common[order(y_common)]
+
+    problems <- x_common[names(x_common) != names(y_common)]
+    if (length(problems) > 0) {
+      problems_msg <- paste(problems[1:min(length(problems), 10)], collapse = ", ")
+      if (length(problems_msg) > 10)
+        problems_msg <- paste0(problems_msg, ", ...")
+
+      warn(c(
+        paste0("`", x_arg, "` and `", y_arg, "` have conflicting value labels."),
+        i = paste0("Labels for these values will be taken from `", x_arg, "`."),
+        x = paste("Values:", problems_msg)
+      ))
+    }
+  }
+
+  c(x_labels, y_labels[!y_labels %in% x_labels])
+}
+
 # TODO: remove when minimum R version >= 3.5
 if (getRversion() < 3.5) {
   isFALSE <- function(x) is.logical(x) && length(x) == 1L && !is.na(x) && !x

--- a/tests/testthat/_snaps/labelled.md
+++ b/tests/testthat/_snaps/labelled.md
@@ -16,6 +16,12 @@
     i Labels for these values will be taken from `..1`.
     x Values: 1, 2
 
+---
+
+    `..1` and `..2` have conflicting value labels.
+    i Labels for these values will be taken from `..1`.
+    x Values: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...
+
 # printed output is stable
 
     Code

--- a/tests/testthat/_snaps/labelled.md
+++ b/tests/testthat/_snaps/labelled.md
@@ -1,3 +1,21 @@
+# take labels from LHS
+
+    `..1` and `..2` have conflicting value labels.
+    i Labels for these values will be taken from `..1`.
+    x Values: 1, 5
+
+---
+
+    `..1` and `..2` have conflicting value labels.
+    i Labels for these values will be taken from `..1`.
+    x Values: 1
+
+# warn only for conflicting labels
+
+    `..1` and `..2` have conflicting value labels.
+    i Labels for these values will be taken from `..1`.
+    x Values: 1, 2
+
 # printed output is stable
 
     Code

--- a/tests/testthat/_snaps/labelled_spss.md
+++ b/tests/testthat/_snaps/labelled_spss.md
@@ -61,3 +61,9 @@
     i Labels for these values will be taken from `..1`.
     x Values: 1, 2
 
+---
+
+    `..1` and `..2` have conflicting value labels.
+    i Labels for these values will be taken from `..1`.
+    x Values: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...
+

--- a/tests/testthat/_snaps/labelled_spss.md
+++ b/tests/testthat/_snaps/labelled_spss.md
@@ -43,3 +43,21 @@
            1  Good
            5   Bad
 
+# take labels from LHS
+
+    `..1` and `..2` have conflicting value labels.
+    i Labels for these values will be taken from `..1`.
+    x Values: 1, 5
+
+---
+
+    `..1` and `..2` have conflicting value labels.
+    i Labels for these values will be taken from `..1`.
+    x Values: 1
+
+# warn only for conflicting labels
+
+    `..1` and `..2` have conflicting value labels.
+    i Labels for these values will be taken from `..1`.
+    x Values: 1, 2
+

--- a/tests/testthat/test-labelled.R
+++ b/tests/testthat/test-labelled.R
@@ -172,6 +172,12 @@ test_that("warn only for conflicting labels", {
     y <- labelled(1:2, c(Female = 1, Male = 2, Other = 3))
     c(x, y)
   })
+
+  expect_snapshot_warning({
+    x <- labelled(1:2, c(a=1,b=2,c=3,d=4,e=5,f=6,g=7,h=8,i=9,j=10,k=11))
+    y <- labelled(1:2, c(A=1,B=2,C=3,D=4,E=5,F=6,G=7,H=8,I=9,J=10,K=11))
+    c(x, y)
+  })
 })
 
 test_that("combining picks label from the left", {

--- a/tests/testthat/test-labelled.R
+++ b/tests/testthat/test-labelled.R
@@ -145,21 +145,33 @@ test_that("can combine names", {
 })
 
 test_that("take labels from LHS", {
-  expect_equal(
-    vec_c(
-      labelled(1, labels = c(Good = 1, Bad = 5)),
-      labelled(5, labels = c(Bad = 1, Good = 5)),
-    ),
-    labelled(c(1, 5), labels = c(Good = 1, Bad = 5))
-  )
+  expect_snapshot_warning({
+    expect_equal(
+      vec_c(
+        labelled(1, labels = c(Good = 1, Bad = 5)),
+        labelled(5, labels = c(Bad = 1, Good = 5)),
+      ),
+      labelled(c(1, 5), labels = c(Good = 1, Bad = 5))
+    )
+  })
 
-  expect_equal(
-    vec_c(
-      labelled(1, labels = c(Good = 1)),
-      labelled(5, labels = c(Bad = 1)),
-    ),
-    labelled(c(1, 5), labels = c(Good = 1))
-  )
+  expect_snapshot_warning({
+    expect_equal(
+      vec_c(
+        labelled(1, labels = c(Good = 1)),
+        labelled(5, labels = c(Bad = 1)),
+      ),
+      labelled(c(1, 5), labels = c(Good = 1))
+    )
+  })
+})
+
+test_that("warn only for conflicting labels", {
+  expect_snapshot_warning({
+    x <- labelled(1:2, c(Yes = 1, No = 2))
+    y <- labelled(1:2, c(Female = 1, Male = 2, Other = 3))
+    c(x, y)
+  })
 })
 
 test_that("combining picks label from the left", {

--- a/tests/testthat/test-labelled_spss.R
+++ b/tests/testthat/test-labelled_spss.R
@@ -181,8 +181,8 @@ test_that("take labels from LHS", {
 
 test_that("warn only for conflicting labels", {
   expect_snapshot_warning({
-    x <- labelled(1:2, c(Yes = 1, No = 2))
-    y <- labelled(1:2, c(Female = 1, Male = 2, Other = 3))
+    x <- labelled_spss(1:2, c(Yes = 1, No = 2))
+    y <- labelled_spss(1:2, c(Female = 1, Male = 2, Other = 3))
     c(x, y)
   })
 })

--- a/tests/testthat/test-labelled_spss.R
+++ b/tests/testthat/test-labelled_spss.R
@@ -158,21 +158,33 @@ test_that("can combine names", {
 })
 
 test_that("take labels from LHS", {
-  expect_equal(
-    vec_c(
-      labelled_spss(1, labels = c(Good = 1, Bad = 5)),
-      labelled_spss(5, labels = c(Bad = 1, Good = 5)),
-    ),
-    labelled_spss(c(1, 5), labels = c(Good = 1, Bad = 5))
-  )
+  expect_snapshot_warning({
+    expect_equal(
+      vec_c(
+        labelled_spss(1, labels = c(Good = 1, Bad = 5)),
+        labelled_spss(5, labels = c(Bad = 1, Good = 5)),
+      ),
+      labelled_spss(c(1, 5), labels = c(Good = 1, Bad = 5))
+    )
+  })
 
-  expect_equal(
-    vec_c(
-      labelled_spss(1, labels = c(Good = 1)),
-      labelled_spss(5, labels = c(Bad = 1)),
-    ),
-    labelled_spss(c(1, 5), labels = c(Good = 1))
-  )
+  expect_snapshot_warning({
+    expect_equal(
+      vec_c(
+        labelled_spss(1, labels = c(Good = 1)),
+        labelled_spss(5, labels = c(Bad = 1)),
+      ),
+      labelled_spss(c(1, 5), labels = c(Good = 1))
+    )
+  })
+})
+
+test_that("warn only for conflicting labels", {
+  expect_snapshot_warning({
+    x <- labelled(1:2, c(Yes = 1, No = 2))
+    y <- labelled(1:2, c(Female = 1, Male = 2, Other = 3))
+    c(x, y)
+  })
 })
 
 test_that("strip user missing if different", {

--- a/tests/testthat/test-labelled_spss.R
+++ b/tests/testthat/test-labelled_spss.R
@@ -185,6 +185,12 @@ test_that("warn only for conflicting labels", {
     y <- labelled_spss(1:2, c(Female = 1, Male = 2, Other = 3))
     c(x, y)
   })
+
+  expect_snapshot_warning({
+    x <- labelled_spss(1:2, c(a=1,b=2,c=3,d=4,e=5,f=6,g=7,h=8,i=9,j=10,k=11))
+    y <- labelled_spss(1:2, c(A=1,B=2,C=3,D=4,E=5,F=6,G=7,H=8,I=9,J=10,K=11))
+    c(x, y)
+  })
 })
 
 test_that("strip user missing if different", {


### PR DESCRIPTION
This PR adds a warning when combining two labelled vectors with conflicting labels, closing #667.

``` r
library(haven)
x <- labelled(1:2, c(Yes = 1, No = 2))
y <- labelled(1:2, c(Female = 1, Male = 2, Other = 3))
c(x, y)
#> Warning: `..1` and `..2` have conflicting value labels.
#> ℹ Labels for these values will be taken from `..1`.
#> x Values: 1, 2
#> <labelled<integer>[4]>
#> [1] 1 2 1 2
#> 
#> Labels:
#>  value label
#>      1   Yes
#>      2    No
#>      3 Other
```

<sup>Created on 2022-03-24 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>