### PR TITLE
Always left align column names for labelled vectors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # haven (development version)
 
+* All `labelled()` vectors now have left-aligned column headers when printing
+  in tibbles for better alignment with labels (#676).
+
 # haven 2.5.0
 
 ## New author

--- a/R/labelled-pillar.R
+++ b/R/labelled-pillar.R
@@ -145,7 +145,7 @@ format.pillar_shaft_haven_labelled_num <- function(x, width, ...) {
     lbl <- str_trunc(x$lbl$disp_full, lbl_width, subtle = TRUE)
     out <- paste_with_align(vshort$main_txt, lbl, vshort$lhs_ws, vshort$rhs_ws)
   }
-  pillar::new_ornament(out, width = width, align = "right")
+  pillar::new_ornament(out, width = width, align = "left")
 }
 
 #' @export

--- a/tests/testthat/_snaps/labelled-pillar.md
+++ b/tests/testthat/_snaps/labelled-pillar.md
@@ -7,13 +7,13 @@
       tibble(int, dbl, chr)
     Output
       # A tibble: 5 x 3
-              int        dbl chr      
-        <int+lbl>  <dbl+lbl> <chr+lbl>
-      1  1 [good] 0.1 [good] a [good] 
-      2  2        0.2        b        
-      3  3        0.3        c        
-      4  4        0.4        d        
-      5  5 [bad]  0.5 [bad]  e [bad]  
+        int       dbl        chr      
+        <int+lbl> <dbl+lbl>  <chr+lbl>
+      1 1 [good]  0.1 [good] a [good] 
+      2 2         0.2        b        
+      3 3         0.3        c        
+      4 4         0.4        d        
+      5 5 [bad]   0.5 [bad]  e [bad]  
 
 # pillar
 
@@ -22,7 +22,7 @@
       tibble::tibble(x)
     Output
       # A tibble: 11 x 1
-                 x
+         x        
          <int+lbl>
        1  1 [Good]
        2  2       
@@ -44,8 +44,8 @@
       tibble::tibble(x)
     Output
       # A tibble: 11 x 1
-                       x
-               <dbl+lbl>
+         x              
+         <dbl+lbl>      
        1    1.22 [One]  
        2    1.22 [One]  
        3    1.22 [One]  
@@ -88,8 +88,8 @@
       tibble::tibble(x)
     Output
       # A tibble: 11 x 1
-                       x
-               <dbl+lbl>
+         x              
+         <dbl+lbl>      
        1     1 [Good]   
        2     2          
        3     3          
@@ -109,8 +109,8 @@
       tibble::tibble(x)
     Output
       # A tibble: 11 x 1
-                         x
-                 <int+lbl>
+         x                
+         <int+lbl>        
        1  1 [Good]        
        2  2               
        3  3               


### PR DESCRIPTION
This PR left aligns column names for labelled vectors, closing #676.

For e.g.
``` r
library(tibble)
library(haven)

x <- tibble(
  col1 = labelled(
    c(1, 5, 8, 9, 1, 8),
    labels = c(Yes = 1, No = 5, `Don't know` = 8, Refused = 9)
  ),
  col2 = labelled(
    c(1, 12, 123, 1234, 1, 123),
    labels = c("a" = 1, "bcd" = 123)
  ),
  col3 = labelled(
    c(1, 12, 123, 1234, 12345, 123456789),
    labels = c("a" = 1, "bcd" = 123)
  ),
  col4 = labelled(
    c("a", "ab", "abc", "abcd", "abcde", "abcdefghijklmno"),
    labels = c("a" = "ab", "bcd" = "abcde")
  )
)

### Before
x
#> # A tibble: 6 × 4
#>             col1       col2            col3 col4           
#>        <dbl+lbl>  <dbl+lbl>       <dbl+lbl> <chr+lbl>      
#> 1 1 [Yes]           1 [a]           1 [a]   a              
#> 2 5 [No]           12              12       ab [a]         
#> 3 8 [Don't know]  123 [bcd]       123 [bcd] abc            
#> 4 9 [Refused]    1234            1234       abcd           
#> 5 1 [Yes]           1 [a]       12345       abcde [bcd]    
#> 6 8 [Don't know]  123 [bcd] 123456789       abcdefghijklmno

### After

x
#> # A tibble: 6 × 4
#>   col1           col2       col3            col4           
#>   <dbl+lbl>      <dbl+lbl>  <dbl+lbl>       <chr+lbl>      
#> 1 1 [Yes]           1 [a]           1 [a]   a              
#> 2 5 [No]           12              12       ab [a]         
#> 3 8 [Don't know]  123 [bcd]       123 [bcd] abc            
#> 4 9 [Refused]    1234            1234       abcd           
#> 5 1 [Yes]           1 [a]       12345       abcde [bcd]    
#> 6 8 [Don't know]  123 [bcd] 123456789       abcdefghijklmno
```

<sup>Created on 2022-04-25 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
