### PR TITLE
Allow functions in `.name_repair`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,6 +43,6 @@ Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 SystemRequirements: GNU make, C++11, zlib: zlib1g-dev (deb), zlib-devel
     (rpm)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * All `labelled()` vectors now have left-aligned column headers when printing
   in tibbles for better alignment with labels (#676).
+  
+* The `write_` functions now accept functions as well as strings in the `.name_repair` argument in line with the documentation. Previously they only supported string values (#684).
 
 # haven 2.5.0
 

--- a/man/haven-package.Rd
+++ b/man/haven-package.Rd
@@ -6,9 +6,9 @@
 \alias{haven-package}
 \title{haven: Import and Export 'SPSS', 'Stata' and 'SAS' Files}
 \description{
-\if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
+\if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-Import foreign statistical formats into R via the embedded 'ReadStat' C library, <https://github.com/WizardMac/ReadStat>.
+Import foreign statistical formats into R via the embedded 'ReadStat' C library, \url{https://github.com/WizardMac/ReadStat}.
 }
 \seealso{
 Useful links:

--- a/src/DfReader.cpp
+++ b/src/DfReader.cpp
@@ -429,7 +429,7 @@ public:
     }
   }
 
-  cpp11::list output(const std::string& name_repair) {
+  cpp11::list output(cpp11::sexp name_repair) {
     if (nrows_ != nrowsAlloc_)
       resizeCols(nrows_);
 
@@ -663,7 +663,7 @@ cpp11::list df_parse(cpp11::list spec, const std::vector<std::string>& cols_skip
               const long& n_max = -1, const long& rows_skip = 0,
               const std::string& encoding = "",
               const bool& user_na = false,
-              const std::string& name_repair = "check_unique",
+              cpp11::sexp name_repair = cpp11::r_string("check_unique"),
               cpp11::list catalog_spec = cpp11::writable::list(R_xlen_t(0)),
               const std::string& catalog_encoding = ""
               ) {
@@ -696,50 +696,50 @@ cpp11::list df_parse(cpp11::list spec, const std::vector<std::string>& cols_skip
 cpp11::list df_parse_sas_file(cpp11::list spec_b7dat, cpp11::list spec_b7cat,
                        std::string encoding, std::string catalog_encoding,
                        std::vector<std::string> cols_skip, long n_max, long rows_skip,
-                       std::string name_repair) {
+                       cpp11::sexp name_repair) {
   return df_parse<HAVEN_SAS7BDAT, DfReaderInputFile>(spec_b7dat, cols_skip, n_max, rows_skip, encoding, false, name_repair, spec_b7cat, catalog_encoding);
 }
 [[cpp11::register]]
 cpp11::list df_parse_sas_raw(cpp11::list spec_b7dat, cpp11::list spec_b7cat,
                       std::string encoding, std::string catalog_encoding,
                       std::vector<std::string> cols_skip, long n_max, long rows_skip,
-                      std::string name_repair) {
+                      cpp11::sexp name_repair) {
   return df_parse<HAVEN_SAS7BDAT, DfReaderInputRaw>(spec_b7dat, cols_skip, n_max, rows_skip, encoding, false, name_repair, spec_b7cat, catalog_encoding);
 }
 
 [[cpp11::register]]
-cpp11::list df_parse_xpt_file(cpp11::list spec, std::vector<std::string> cols_skip, long n_max, long rows_skip, std::string name_repair) {
+cpp11::list df_parse_xpt_file(cpp11::list spec, std::vector<std::string> cols_skip, long n_max, long rows_skip, cpp11::sexp name_repair) {
   return df_parse<HAVEN_XPT, DfReaderInputFile>(spec, cols_skip, n_max, rows_skip, "", false, name_repair);
 }
 [[cpp11::register]]
-cpp11::list df_parse_xpt_raw(cpp11::list spec, std::vector<std::string> cols_skip, long n_max, long rows_skip, std::string name_repair) {
+cpp11::list df_parse_xpt_raw(cpp11::list spec, std::vector<std::string> cols_skip, long n_max, long rows_skip, cpp11::sexp name_repair) {
   return df_parse<HAVEN_XPT, DfReaderInputRaw>(spec, cols_skip, n_max, rows_skip, "", false, name_repair);
 }
 
 [[cpp11::register]]
-cpp11::list df_parse_dta_file(cpp11::list spec, std::string encoding, std::vector<std::string> cols_skip, long n_max, long rows_skip, std::string name_repair) {
+cpp11::list df_parse_dta_file(cpp11::list spec, std::string encoding, std::vector<std::string> cols_skip, long n_max, long rows_skip, cpp11::sexp name_repair) {
   return df_parse<HAVEN_DTA, DfReaderInputFile>(spec, cols_skip, n_max, rows_skip, encoding, false, name_repair);
 }
 [[cpp11::register]]
-cpp11::list df_parse_dta_raw(cpp11::list spec, std::string encoding, std::vector<std::string> cols_skip, long n_max, long rows_skip, std::string name_repair) {
+cpp11::list df_parse_dta_raw(cpp11::list spec, std::string encoding, std::vector<std::string> cols_skip, long n_max, long rows_skip, cpp11::sexp name_repair) {
   return df_parse<HAVEN_DTA, DfReaderInputRaw>(spec, cols_skip, n_max, rows_skip, encoding, false, name_repair);
 }
 
 [[cpp11::register]]
-cpp11::list df_parse_sav_file(cpp11::list spec, std::string encoding, bool user_na, std::vector<std::string> cols_skip, long n_max, long rows_skip, std::string name_repair) {
+cpp11::list df_parse_sav_file(cpp11::list spec, std::string encoding, bool user_na, std::vector<std::string> cols_skip, long n_max, long rows_skip, cpp11::sexp name_repair) {
   return df_parse<HAVEN_SAV, DfReaderInputFile>(spec, cols_skip, n_max, rows_skip, encoding, user_na, name_repair);
 }
 [[cpp11::register]]
-cpp11::list df_parse_sav_raw(cpp11::list spec, std::string encoding, bool user_na, std::vector<std::string> cols_skip, long n_max, long rows_skip, std::string name_repair) {
+cpp11::list df_parse_sav_raw(cpp11::list spec, std::string encoding, bool user_na, std::vector<std::string> cols_skip, long n_max, long rows_skip, cpp11::sexp name_repair) {
   return df_parse<HAVEN_SAV, DfReaderInputRaw>(spec, cols_skip, n_max, rows_skip, encoding, user_na, name_repair);
 }
 
 [[cpp11::register]]
-cpp11::list df_parse_por_file(cpp11::list spec, std::string encoding, bool user_na, std::vector<std::string> cols_skip, long n_max, long rows_skip, std::string name_repair) {
+cpp11::list df_parse_por_file(cpp11::list spec, std::string encoding, bool user_na, std::vector<std::string> cols_skip, long n_max, long rows_skip, cpp11::sexp name_repair) {
   return df_parse<HAVEN_POR, DfReaderInputFile>(spec, cols_skip, n_max, rows_skip, encoding, user_na, name_repair);
 }
 [[cpp11::register]]
-cpp11::list df_parse_por_raw(cpp11::list spec, std::string encoding, bool user_na, std::vector<std::string> cols_skip, long n_max, long rows_skip, std::string name_repair) {
+cpp11::list df_parse_por_raw(cpp11::list spec, std::string encoding, bool user_na, std::vector<std::string> cols_skip, long n_max, long rows_skip, cpp11::sexp name_repair) {
   return df_parse<HAVEN_POR, DfReaderInputRaw>(spec, cols_skip, n_max, rows_skip, encoding, user_na, name_repair);
 }
 

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -6,73 +6,73 @@
 #include <R_ext/Visibility.h>
 
 // DfReader.cpp
-cpp11::list df_parse_sas_file(cpp11::list spec_b7dat, cpp11::list spec_b7cat, std::string encoding, std::string catalog_encoding, std::vector<std::string> cols_skip, long n_max, long rows_skip, std::string name_repair);
+cpp11::list df_parse_sas_file(cpp11::list spec_b7dat, cpp11::list spec_b7cat, std::string encoding, std::string catalog_encoding, std::vector<std::string> cols_skip, long n_max, long rows_skip, cpp11::sexp name_repair);
 extern "C" SEXP _haven_df_parse_sas_file(SEXP spec_b7dat, SEXP spec_b7cat, SEXP encoding, SEXP catalog_encoding, SEXP cols_skip, SEXP n_max, SEXP rows_skip, SEXP name_repair) {
   BEGIN_CPP11
-    return cpp11::as_sexp(df_parse_sas_file(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec_b7dat), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec_b7cat), cpp11::as_cpp<cpp11::decay_t<std::string>>(encoding), cpp11::as_cpp<cpp11::decay_t<std::string>>(catalog_encoding), cpp11::as_cpp<cpp11::decay_t<std::vector<std::string>>>(cols_skip), cpp11::as_cpp<cpp11::decay_t<long>>(n_max), cpp11::as_cpp<cpp11::decay_t<long>>(rows_skip), cpp11::as_cpp<cpp11::decay_t<std::string>>(name_repair)));
+    return cpp11::as_sexp(df_parse_sas_file(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec_b7dat), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec_b7cat), cpp11::as_cpp<cpp11::decay_t<std::string>>(encoding), cpp11::as_cpp<cpp11::decay_t<std::string>>(catalog_encoding), cpp11::as_cpp<cpp11::decay_t<std::vector<std::string>>>(cols_skip), cpp11::as_cpp<cpp11::decay_t<long>>(n_max), cpp11::as_cpp<cpp11::decay_t<long>>(rows_skip), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(name_repair)));
   END_CPP11
 }
 // DfReader.cpp
-cpp11::list df_parse_sas_raw(cpp11::list spec_b7dat, cpp11::list spec_b7cat, std::string encoding, std::string catalog_encoding, std::vector<std::string> cols_skip, long n_max, long rows_skip, std::string name_repair);
+cpp11::list df_parse_sas_raw(cpp11::list spec_b7dat, cpp11::list spec_b7cat, std::string encoding, std::string catalog_encoding, std::vector<std::string> cols_skip, long n_max, long rows_skip, cpp11::sexp name_repair);
 extern "C" SEXP _haven_df_parse_sas_raw(SEXP spec_b7dat, SEXP spec_b7cat, SEXP encoding, SEXP catalog_encoding, SEXP cols_skip, SEXP n_max, SEXP rows_skip, SEXP name_repair) {
   BEGIN_CPP11
-    return cpp11::as_sexp(df_parse_sas_raw(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec_b7dat), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec_b7cat), cpp11::as_cpp<cpp11::decay_t<std::string>>(encoding), cpp11::as_cpp<cpp11::decay_t<std::string>>(catalog_encoding), cpp11::as_cpp<cpp11::decay_t<std::vector<std::string>>>(cols_skip), cpp11::as_cpp<cpp11::decay_t<long>>(n_max), cpp11::as_cpp<cpp11::decay_t<long>>(rows_skip), cpp11::as_cpp<cpp11::decay_t<std::string>>(name_repair)));
+    return cpp11::as_sexp(df_parse_sas_raw(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec_b7dat), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec_b7cat), cpp11::as_cpp<cpp11::decay_t<std::string>>(encoding), cpp11::as_cpp<cpp11::decay_t<std::string>>(catalog_encoding), cpp11::as_cpp<cpp11::decay_t<std::vector<std::string>>>(cols_skip), cpp11::as_cpp<cpp11::decay_t<long>>(n_max), cpp11::as_cpp<cpp11::decay_t<long>>(rows_skip), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(name_repair)));
   END_CPP11
 }
 // DfReader.cpp
-cpp11::list df_parse_xpt_file(cpp11::list spec, std::vector<std::string> cols_skip, long n_max, long rows_skip, std::string name_repair);
+cpp11::list df_parse_xpt_file(cpp11::list spec, std::vector<std::string> cols_skip, long n_max, long rows_skip, cpp11::sexp name_repair);
 extern "C" SEXP _haven_df_parse_xpt_file(SEXP spec, SEXP cols_skip, SEXP n_max, SEXP rows_skip, SEXP name_repair) {
   BEGIN_CPP11
-    return cpp11::as_sexp(df_parse_xpt_file(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec), cpp11::as_cpp<cpp11::decay_t<std::vector<std::string>>>(cols_skip), cpp11::as_cpp<cpp11::decay_t<long>>(n_max), cpp11::as_cpp<cpp11::decay_t<long>>(rows_skip), cpp11::as_cpp<cpp11::decay_t<std::string>>(name_repair)));
+    return cpp11::as_sexp(df_parse_xpt_file(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec), cpp11::as_cpp<cpp11::decay_t<std::vector<std::string>>>(cols_skip), cpp11::as_cpp<cpp11::decay_t<long>>(n_max), cpp11::as_cpp<cpp11::decay_t<long>>(rows_skip), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(name_repair)));
   END_CPP11
 }
 // DfReader.cpp
-cpp11::list df_parse_xpt_raw(cpp11::list spec, std::vector<std::string> cols_skip, long n_max, long rows_skip, std::string name_repair);
+cpp11::list df_parse_xpt_raw(cpp11::list spec, std::vector<std::string> cols_skip, long n_max, long rows_skip, cpp11::sexp name_repair);
 extern "C" SEXP _haven_df_parse_xpt_raw(SEXP spec, SEXP cols_skip, SEXP n_max, SEXP rows_skip, SEXP name_repair) {
   BEGIN_CPP11
-    return cpp11::as_sexp(df_parse_xpt_raw(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec), cpp11::as_cpp<cpp11::decay_t<std::vector<std::string>>>(cols_skip), cpp11::as_cpp<cpp11::decay_t<long>>(n_max), cpp11::as_cpp<cpp11::decay_t<long>>(rows_skip), cpp11::as_cpp<cpp11::decay_t<std::string>>(name_repair)));
+    return cpp11::as_sexp(df_parse_xpt_raw(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec), cpp11::as_cpp<cpp11::decay_t<std::vector<std::string>>>(cols_skip), cpp11::as_cpp<cpp11::decay_t<long>>(n_max), cpp11::as_cpp<cpp11::decay_t<long>>(rows_skip), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(name_repair)));
   END_CPP11
 }
 // DfReader.cpp
-cpp11::list df_parse_dta_file(cpp11::list spec, std::string encoding, std::vector<std::string> cols_skip, long n_max, long rows_skip, std::string name_repair);
+cpp11::list df_parse_dta_file(cpp11::list spec, std::string encoding, std::vector<std::string> cols_skip, long n_max, long rows_skip, cpp11::sexp name_repair);
 extern "C" SEXP _haven_df_parse_dta_file(SEXP spec, SEXP encoding, SEXP cols_skip, SEXP n_max, SEXP rows_skip, SEXP name_repair) {
   BEGIN_CPP11
-    return cpp11::as_sexp(df_parse_dta_file(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec), cpp11::as_cpp<cpp11::decay_t<std::string>>(encoding), cpp11::as_cpp<cpp11::decay_t<std::vector<std::string>>>(cols_skip), cpp11::as_cpp<cpp11::decay_t<long>>(n_max), cpp11::as_cpp<cpp11::decay_t<long>>(rows_skip), cpp11::as_cpp<cpp11::decay_t<std::string>>(name_repair)));
+    return cpp11::as_sexp(df_parse_dta_file(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec), cpp11::as_cpp<cpp11::decay_t<std::string>>(encoding), cpp11::as_cpp<cpp11::decay_t<std::vector<std::string>>>(cols_skip), cpp11::as_cpp<cpp11::decay_t<long>>(n_max), cpp11::as_cpp<cpp11::decay_t<long>>(rows_skip), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(name_repair)));
   END_CPP11
 }
 // DfReader.cpp
-cpp11::list df_parse_dta_raw(cpp11::list spec, std::string encoding, std::vector<std::string> cols_skip, long n_max, long rows_skip, std::string name_repair);
+cpp11::list df_parse_dta_raw(cpp11::list spec, std::string encoding, std::vector<std::string> cols_skip, long n_max, long rows_skip, cpp11::sexp name_repair);
 extern "C" SEXP _haven_df_parse_dta_raw(SEXP spec, SEXP encoding, SEXP cols_skip, SEXP n_max, SEXP rows_skip, SEXP name_repair) {
   BEGIN_CPP11
-    return cpp11::as_sexp(df_parse_dta_raw(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec), cpp11::as_cpp<cpp11::decay_t<std::string>>(encoding), cpp11::as_cpp<cpp11::decay_t<std::vector<std::string>>>(cols_skip), cpp11::as_cpp<cpp11::decay_t<long>>(n_max), cpp11::as_cpp<cpp11::decay_t<long>>(rows_skip), cpp11::as_cpp<cpp11::decay_t<std::string>>(name_repair)));
+    return cpp11::as_sexp(df_parse_dta_raw(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec), cpp11::as_cpp<cpp11::decay_t<std::string>>(encoding), cpp11::as_cpp<cpp11::decay_t<std::vector<std::string>>>(cols_skip), cpp11::as_cpp<cpp11::decay_t<long>>(n_max), cpp11::as_cpp<cpp11::decay_t<long>>(rows_skip), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(name_repair)));
   END_CPP11
 }
 // DfReader.cpp
-cpp11::list df_parse_sav_file(cpp11::list spec, std::string encoding, bool user_na, std::vector<std::string> cols_skip, long n_max, long rows_skip, std::string name_repair);
+cpp11::list df_parse_sav_file(cpp11::list spec, std::string encoding, bool user_na, std::vector<std::string> cols_skip, long n_max, long rows_skip, cpp11::sexp name_repair);
 extern "C" SEXP _haven_df_parse_sav_file(SEXP spec, SEXP encoding, SEXP user_na, SEXP cols_skip, SEXP n_max, SEXP rows_skip, SEXP name_repair) {
   BEGIN_CPP11
-    return cpp11::as_sexp(df_parse_sav_file(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec), cpp11::as_cpp<cpp11::decay_t<std::string>>(encoding), cpp11::as_cpp<cpp11::decay_t<bool>>(user_na), cpp11::as_cpp<cpp11::decay_t<std::vector<std::string>>>(cols_skip), cpp11::as_cpp<cpp11::decay_t<long>>(n_max), cpp11::as_cpp<cpp11::decay_t<long>>(rows_skip), cpp11::as_cpp<cpp11::decay_t<std::string>>(name_repair)));
+    return cpp11::as_sexp(df_parse_sav_file(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec), cpp11::as_cpp<cpp11::decay_t<std::string>>(encoding), cpp11::as_cpp<cpp11::decay_t<bool>>(user_na), cpp11::as_cpp<cpp11::decay_t<std::vector<std::string>>>(cols_skip), cpp11::as_cpp<cpp11::decay_t<long>>(n_max), cpp11::as_cpp<cpp11::decay_t<long>>(rows_skip), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(name_repair)));
   END_CPP11
 }
 // DfReader.cpp
-cpp11::list df_parse_sav_raw(cpp11::list spec, std::string encoding, bool user_na, std::vector<std::string> cols_skip, long n_max, long rows_skip, std::string name_repair);
+cpp11::list df_parse_sav_raw(cpp11::list spec, std::string encoding, bool user_na, std::vector<std::string> cols_skip, long n_max, long rows_skip, cpp11::sexp name_repair);
 extern "C" SEXP _haven_df_parse_sav_raw(SEXP spec, SEXP encoding, SEXP user_na, SEXP cols_skip, SEXP n_max, SEXP rows_skip, SEXP name_repair) {
   BEGIN_CPP11
-    return cpp11::as_sexp(df_parse_sav_raw(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec), cpp11::as_cpp<cpp11::decay_t<std::string>>(encoding), cpp11::as_cpp<cpp11::decay_t<bool>>(user_na), cpp11::as_cpp<cpp11::decay_t<std::vector<std::string>>>(cols_skip), cpp11::as_cpp<cpp11::decay_t<long>>(n_max), cpp11::as_cpp<cpp11::decay_t<long>>(rows_skip), cpp11::as_cpp<cpp11::decay_t<std::string>>(name_repair)));
+    return cpp11::as_sexp(df_parse_sav_raw(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec), cpp11::as_cpp<cpp11::decay_t<std::string>>(encoding), cpp11::as_cpp<cpp11::decay_t<bool>>(user_na), cpp11::as_cpp<cpp11::decay_t<std::vector<std::string>>>(cols_skip), cpp11::as_cpp<cpp11::decay_t<long>>(n_max), cpp11::as_cpp<cpp11::decay_t<long>>(rows_skip), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(name_repair)));
   END_CPP11
 }
 // DfReader.cpp
-cpp11::list df_parse_por_file(cpp11::list spec, std::string encoding, bool user_na, std::vector<std::string> cols_skip, long n_max, long rows_skip, std::string name_repair);
+cpp11::list df_parse_por_file(cpp11::list spec, std::string encoding, bool user_na, std::vector<std::string> cols_skip, long n_max, long rows_skip, cpp11::sexp name_repair);
 extern "C" SEXP _haven_df_parse_por_file(SEXP spec, SEXP encoding, SEXP user_na, SEXP cols_skip, SEXP n_max, SEXP rows_skip, SEXP name_repair) {
   BEGIN_CPP11
-    return cpp11::as_sexp(df_parse_por_file(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec), cpp11::as_cpp<cpp11::decay_t<std::string>>(encoding), cpp11::as_cpp<cpp11::decay_t<bool>>(user_na), cpp11::as_cpp<cpp11::decay_t<std::vector<std::string>>>(cols_skip), cpp11::as_cpp<cpp11::decay_t<long>>(n_max), cpp11::as_cpp<cpp11::decay_t<long>>(rows_skip), cpp11::as_cpp<cpp11::decay_t<std::string>>(name_repair)));
+    return cpp11::as_sexp(df_parse_por_file(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec), cpp11::as_cpp<cpp11::decay_t<std::string>>(encoding), cpp11::as_cpp<cpp11::decay_t<bool>>(user_na), cpp11::as_cpp<cpp11::decay_t<std::vector<std::string>>>(cols_skip), cpp11::as_cpp<cpp11::decay_t<long>>(n_max), cpp11::as_cpp<cpp11::decay_t<long>>(rows_skip), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(name_repair)));
   END_CPP11
 }
 // DfReader.cpp
-cpp11::list df_parse_por_raw(cpp11::list spec, std::string encoding, bool user_na, std::vector<std::string> cols_skip, long n_max, long rows_skip, std::string name_repair);
+cpp11::list df_parse_por_raw(cpp11::list spec, std::string encoding, bool user_na, std::vector<std::string> cols_skip, long n_max, long rows_skip, cpp11::sexp name_repair);
 extern "C" SEXP _haven_df_parse_por_raw(SEXP spec, SEXP encoding, SEXP user_na, SEXP cols_skip, SEXP n_max, SEXP rows_skip, SEXP name_repair) {
   BEGIN_CPP11
-    return cpp11::as_sexp(df_parse_por_raw(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec), cpp11::as_cpp<cpp11::decay_t<std::string>>(encoding), cpp11::as_cpp<cpp11::decay_t<bool>>(user_na), cpp11::as_cpp<cpp11::decay_t<std::vector<std::string>>>(cols_skip), cpp11::as_cpp<cpp11::decay_t<long>>(n_max), cpp11::as_cpp<cpp11::decay_t<long>>(rows_skip), cpp11::as_cpp<cpp11::decay_t<std::string>>(name_repair)));
+    return cpp11::as_sexp(df_parse_por_raw(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(spec), cpp11::as_cpp<cpp11::decay_t<std::string>>(encoding), cpp11::as_cpp<cpp11::decay_t<bool>>(user_na), cpp11::as_cpp<cpp11::decay_t<std::vector<std::string>>>(cols_skip), cpp11::as_cpp<cpp11::decay_t<long>>(n_max), cpp11::as_cpp<cpp11::decay_t<long>>(rows_skip), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(name_repair)));
   END_CPP11
 }
 // DfWriter.cpp

--- a/tests/testthat/test-haven-sas.R
+++ b/tests/testthat/test-haven-sas.R
@@ -45,8 +45,13 @@ test_that("default name repair can be overridden", {
   path <- tempfile()
   write_sas(df, path)
 
-  expect_message(read_sas(path), "id...1")
-  expect_message(read_sas(path, .name_repair = "minimal"), NA)
+  expect_message(
+    expect_equal(names(read_sas(path)), c("id...1", "id...2")),
+    "id...1"
+  )
+  expect_equal(names(read_sas(path, .name_repair = "minimal")), c("id", "id"))
+  expect_equal(names(read_sas(path, .name_repair = make.names)), c("id", "id"))
+  expect_equal(names(read_sas(path, .name_repair = ~rep_len("a", length(.x)))), c("a", "a"))
 })
 
 test_that("connections are read", {


### PR DESCRIPTION
This PR fixes #684.

I've modified the `.name_repair` argument to allow an arbitrary SEXP instead of a `std::string`, allowing users to pass a function in `.name_repair` to `tibble::as_tibble()`.