### PR TITLE
Update to ReadStat 1.1.9

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # haven (development version)
 
+* Updated to ReadStat 1.1.9.
+
+  * Fix various SAS catalog file reading bugs (#529, #653, #680, #696, #705).
+  * Increase maximum SAS page file size to 16MiB (#697).
+  * Ignore invalid SAV timestamp strings (#683).
+  * Fix compiler warnings (#707).
+
 * The experimental `write_sas()` function has been deprecated (#224). The
   sas7bdat file format is complex and undocumented, and as such writing SAS
   files is not officially supported by ReadStat. `write_xpt()` should be used

--- a/src/readstat/NEWS
+++ b/src/readstat/NEWS
@@ -1,7 +1,21 @@
+New in 1.1.9:
+
+    * SAV reader: Improved support for Asian code pages #263
+    * SAV reader: Improved support for Very Long String records #287
+    * SAS reader: Improved support for RLE decompression #245 #253
+    * SAS reader: Support 16MiB page sizes #286
+    * SAS catalog reader: Fix bugs reading big-endian files #293
+    * SAS catalog reader: Allow formats with no labels #290
+    * SAS catalog reader: Check for long names in 64-bit files #291
+    * Improved compatibility with -Wstrict-prototypes #295
+    * Replace sprintf with snprintf #292
+
 New in 1.1.8:
 
     * XPT reader/writer: Improved support for format strings #257 #258
+    * DTA writer: Fix off-by-one error in v,o indexing for string refs #270
     * SAV/DTA writers: Improved checking of non-ASCII characters #256
+    * SAS7BDAT reader: Fix use-after-free error #273
     * Build: Link to libm on GNU systems #255
     * SAS commands: Support more syntax
     * SPSS commands: Make file names optional

--- a/src/readstat/readstat_bits.h
+++ b/src/readstat/readstat_bits.h
@@ -7,7 +7,7 @@
 #undef READSTAT_MACHINE_IS_TWOS_COMPLEMENT
 #define READSTAT_MACHINE_IS_TWOS_COMPLEMENT 0
 
-int machine_is_little_endian();
+int machine_is_little_endian(void);
 
 char ones_to_twos_complement1(char num);
 int16_t ones_to_twos_complement2(int16_t num);

--- a/src/readstat/readstat_convert.c
+++ b/src/readstat/readstat_convert.c
@@ -7,7 +7,7 @@
 readstat_error_t readstat_convert(char *dst, size_t dst_len, const char *src, size_t src_len, iconv_t converter) {
     /* strip off spaces from the input because the programs use ASCII space
      * padding even with non-ASCII encoding. */
-    while (src_len && src[src_len-1] == ' ') {
+    while (src_len && (src[src_len-1] == ' ' || src[src_len-1] == '\0')) {
         src_len--;
     }
     if (dst_len == 0) {

--- a/src/readstat/readstat_malloc.c
+++ b/src/readstat/readstat_malloc.c
@@ -1,9 +1,11 @@
 #include <stdlib.h>
 
-#define MAX_MALLOC_SIZE 0xFFF000
-/* ~16 MB. Needs to be at least 0x3FF00, i.e. the default ~4MB block size used
- * in compressed SPSS (ZSAV) files. The purpose here is to prevent massive
- * allocations in the event of a malformed file or a bug in the library. */
+#define MAX_MALLOC_SIZE 0x1000000
+/* =16 MiB. Needs to be at least 0x3FF00, i.e. the default ~4MB block size used
+ * in compressed SPSS (ZSAV) files. Some SAS installations use 16MiB page sizes
+ * by default, see https://github.com/tidyverse/haven/issues/697.
+ * The purpose here is to prevent massive allocations in the event of a
+ * malformed file or a bug in the library. */
 
 void *readstat_malloc(size_t len) {
     if (len > MAX_MALLOC_SIZE || len == 0) {

--- a/src/readstat/readstat_variable.c
+++ b/src/readstat/readstat_variable.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include "readstat.h"
 
-static readstat_value_t make_blank_value();
+static readstat_value_t make_blank_value(void);
 static readstat_value_t make_double_value(double dval);
 
 static readstat_value_t make_blank_value() {

--- a/src/readstat/sas/ieee.c
+++ b/src/readstat/sas/ieee.c
@@ -16,7 +16,7 @@ static void ieee2xpt(unsigned char *ieee, unsigned char *xport);
 
 #ifndef FLOATREP
 #define FLOATREP get_native()
-int get_native();
+int get_native(void);
 #endif
 
 void memreverse(void *intp_void, int l) {

--- a/src/readstat/sas/readstat_sas7bdat_read.c
+++ b/src/readstat/sas/readstat_sas7bdat_read.c
@@ -703,7 +703,6 @@ static readstat_variable_t *sas7bdat_init_variable(sas7bdat_ctx_t *ctx, int i,
 
 cleanup:
     if (retval != READSTAT_OK) {
-        free(variable);
         if (out_retval)
             *out_retval = retval;
 
@@ -715,6 +714,8 @@ cleanup:
                 ctx->handle.error(ctx->error_buf, ctx->user_ctx);
             }
         }
+
+        free(variable);
 
         return NULL;
     }

--- a/src/readstat/sas/readstat_sas_rle.c
+++ b/src/readstat/sas/readstat_sas_rle.c
@@ -11,6 +11,8 @@ typedef SSIZE_T ssize_t;
 #include "readstat_sas_rle.h"
 
 #define SAS_RLE_COMMAND_COPY64          0
+#define SAS_RLE_COMMAND_COPY64_PLUS_4096 1
+#define SAS_RLE_COMMAND_COPY96          2
 #define SAS_RLE_COMMAND_INSERT_BYTE18   4
 #define SAS_RLE_COMMAND_INSERT_AT17     5
 #define SAS_RLE_COMMAND_INSERT_BLANK17  6
@@ -29,6 +31,7 @@ typedef SSIZE_T ssize_t;
 
 static size_t command_lengths[16] = {
     [SAS_RLE_COMMAND_COPY64] = 1,
+    [SAS_RLE_COMMAND_COPY64_PLUS_4096] = 1,
     [SAS_RLE_COMMAND_INSERT_BYTE18] = 2,
     [SAS_RLE_COMMAND_INSERT_AT17] = 1,
     [SAS_RLE_COMMAND_INSERT_BLANK17] = 1,
@@ -62,6 +65,10 @@ ssize_t sas_rle_decompress(void *output_buf, size_t output_len,
             case SAS_RLE_COMMAND_COPY64:
                 copy_len = (*input++) + 64 + length * 256;
                 break;
+            case SAS_RLE_COMMAND_COPY64_PLUS_4096:
+                copy_len = (*input++) + 64 + length * 256 + 4096;
+                break;
+            case SAS_RLE_COMMAND_COPY96: copy_len = length + 96; break;
             case SAS_RLE_COMMAND_INSERT_BYTE18:
                 insert_len = (*input++) + 18 + length * 256;
                 insert_byte = *input++;

--- a/src/readstat/spss/readstat_por.c
+++ b/src/readstat/spss/readstat_por.c
@@ -129,7 +129,7 @@ ssize_t por_utf8_encode(const unsigned char *input, size_t input_len,
             }
             /* TODO - For some reason that replacement character isn't recognized
              * by some systems, so be prepared to insert an ASCII space instead */
-            int printed = sprintf(output + offset, "%lc", codepoint);
+            int printed = snprintf(output + offset, output_len - offset, "%lc", codepoint);
             if (printed > 0) {
                 offset += printed;
             } else {

--- a/src/readstat/spss/readstat_por.h
+++ b/src/readstat/spss/readstat_por.h
@@ -31,7 +31,7 @@ typedef struct por_ctx_s {
     ck_hash_table_t *var_dict;
 } por_ctx_t;
 
-por_ctx_t *por_ctx_init();
+por_ctx_t *por_ctx_init(void);
 void por_ctx_free(por_ctx_t *ctx);
 ssize_t por_utf8_encode(const unsigned char *input, size_t input_len, 
         char *output, size_t output_len, uint16_t lookup[256]);

--- a/src/readstat/spss/readstat_sav_parse.c
+++ b/src/readstat/spss/readstat_sav_parse.c
@@ -564,7 +564,7 @@ static const signed char _sav_very_long_string_parse_actions[] = {
 
 static const signed char _sav_very_long_string_parse_key_offsets[] = {
 	0, 0, 5, 19, 33, 47, 61, 75,
-	89, 103, 104, 106, 109, 111, 0
+	89, 103, 104, 106, 110, 112, 0
 };
 
 static const unsigned char _sav_very_long_string_parse_trans_keys[] = {
@@ -581,13 +581,13 @@ static const unsigned char _sav_very_long_string_parse_trans_keys[] = {
 	34u, 37u, 45u, 58u, 63u, 91u, 94u, 123u,
 	127u, 47u, 61u, 96u, 255u, 0u, 34u, 37u,
 	45u, 58u, 63u, 91u, 94u, 123u, 127u, 61u,
-	48u, 57u, 0u, 48u, 57u, 0u, 9u, 255u,
-	0u, 63u, 91u, 127u, 0u
+	48u, 57u, 0u, 9u, 48u, 57u, 0u, 9u,
+	255u, 0u, 63u, 91u, 127u, 0u
 };
 
 static const signed char _sav_very_long_string_parse_single_lengths[] = {
 	0, 1, 4, 4, 4, 4, 4, 4,
-	4, 1, 0, 1, 2, 1, 0
+	4, 1, 0, 2, 2, 1, 0
 };
 
 static const signed char _sav_very_long_string_parse_range_lengths[] = {
@@ -597,7 +597,7 @@ static const signed char _sav_very_long_string_parse_range_lengths[] = {
 
 static const signed char _sav_very_long_string_parse_index_offsets[] = {
 	0, 0, 4, 14, 24, 34, 44, 54,
-	64, 74, 76, 78, 81, 84, 0
+	64, 74, 76, 78, 82, 85, 0
 };
 
 static const signed char _sav_very_long_string_parse_cond_targs[] = {
@@ -610,10 +610,10 @@ static const signed char _sav_very_long_string_parse_cond_targs[] = {
 	0, 0, 0, 0, 0, 7, 0, 10,
 	0, 0, 0, 0, 0, 0, 0, 8,
 	0, 10, 0, 0, 0, 0, 0, 0,
-	0, 9, 10, 0, 11, 0, 12, 11,
-	0, 12, 13, 0, 0, 0, 0, 2,
-	0, 1, 2, 3, 4, 5, 6, 7,
-	8, 9, 10, 11, 12, 13, 0
+	0, 9, 10, 0, 11, 0, 12, 13,
+	11, 0, 12, 13, 0, 0, 0, 0,
+	2, 0, 1, 2, 3, 4, 5, 6,
+	7, 8, 9, 10, 11, 12, 13, 0
 };
 
 static const signed char _sav_very_long_string_parse_cond_actions[] = {
@@ -626,10 +626,15 @@ static const signed char _sav_very_long_string_parse_cond_actions[] = {
 	0, 0, 0, 0, 0, 0, 0, 7,
 	0, 0, 0, 0, 0, 0, 0, 0,
 	0, 7, 0, 0, 0, 0, 0, 0,
-	0, 0, 7, 0, 10, 0, 3, 5,
-	0, 0, 0, 0, 0, 0, 0, 1,
-	0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0
+	0, 0, 7, 0, 10, 0, 3, 3,
+	5, 0, 0, 0, 0, 0, 0, 0,
+	1, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 3, 0, 0, 0
+};
+
+static const signed char _sav_very_long_string_parse_eof_trans[] = {
+	90, 91, 92, 93, 94, 95, 96, 97,
+	98, 99, 100, 101, 102, 103, 0
 };
 
 static const int sav_very_long_string_parse_start = 1;
@@ -654,6 +659,7 @@ readstat_error_t sav_parse_very_long_string_record(void *data, int count, sav_ct
 	char *error_buf = NULL;
 	unsigned char *p = c_data;
 	unsigned char *pe = c_data + count;
+	unsigned char *eof = pe;
 	
 	varlookup_t *table = NULL;
 	int cs;
@@ -662,12 +668,12 @@ readstat_error_t sav_parse_very_long_string_record(void *data, int count, sav_ct
 	table = build_lookup_table(var_count, ctx);
 	
 	
-#line 666 "src/spss/readstat_sav_parse.c"
+#line 672 "src/spss/readstat_sav_parse.c"
 	{
 		cs = (int)sav_very_long_string_parse_start;
 	}
 	
-#line 671 "src/spss/readstat_sav_parse.c"
+#line 677 "src/spss/readstat_sav_parse.c"
 	{
 		int _klen;
 		unsigned int _trans = 0;
@@ -675,59 +681,66 @@ readstat_error_t sav_parse_very_long_string_record(void *data, int count, sav_ct
 		const signed char * _acts;
 		unsigned int _nacts;
 		_resume: {}
-		if ( p == pe )
+		if ( p == pe && p != eof )
 			goto _out;
-		_keys = ( _sav_very_long_string_parse_trans_keys + (_sav_very_long_string_parse_key_offsets[cs]));
-		_trans = (unsigned int)_sav_very_long_string_parse_index_offsets[cs];
-		
-		_klen = (int)_sav_very_long_string_parse_single_lengths[cs];
-		if ( _klen > 0 ) {
-			const unsigned char *_lower = _keys;
-			const unsigned char *_upper = _keys + _klen - 1;
-			const unsigned char *_mid;
-			while ( 1 ) {
-				if ( _upper < _lower ) {
-					_keys += _klen;
-					_trans += (unsigned int)_klen;
-					break;
-				}
-				
-				_mid = _lower + ((_upper-_lower) >> 1);
-				if ( ( (*( p))) < (*( _mid)) )
-					_upper = _mid - 1;
-				else if ( ( (*( p))) > (*( _mid)) )
-					_lower = _mid + 1;
-				else {
-					_trans += (unsigned int)(_mid - _keys);
-					goto _match;
-				}
+		if ( p == eof ) {
+			if ( _sav_very_long_string_parse_eof_trans[cs] > 0 ) {
+				_trans = (unsigned int)_sav_very_long_string_parse_eof_trans[cs] - 1;
 			}
 		}
-		
-		_klen = (int)_sav_very_long_string_parse_range_lengths[cs];
-		if ( _klen > 0 ) {
-			const unsigned char *_lower = _keys;
-			const unsigned char *_upper = _keys + (_klen<<1) - 2;
-			const unsigned char *_mid;
-			while ( 1 ) {
-				if ( _upper < _lower ) {
-					_trans += (unsigned int)_klen;
-					break;
-				}
-				
-				_mid = _lower + (((_upper-_lower) >> 1) & ~1);
-				if ( ( (*( p))) < (*( _mid)) )
-					_upper = _mid - 2;
-				else if ( ( (*( p))) > (*( _mid + 1)) )
-					_lower = _mid + 2;
-				else {
-					_trans += (unsigned int)((_mid - _keys)>>1);
-					break;
+		else {
+			_keys = ( _sav_very_long_string_parse_trans_keys + (_sav_very_long_string_parse_key_offsets[cs]));
+			_trans = (unsigned int)_sav_very_long_string_parse_index_offsets[cs];
+			
+			_klen = (int)_sav_very_long_string_parse_single_lengths[cs];
+			if ( _klen > 0 ) {
+				const unsigned char *_lower = _keys;
+				const unsigned char *_upper = _keys + _klen - 1;
+				const unsigned char *_mid;
+				while ( 1 ) {
+					if ( _upper < _lower ) {
+						_keys += _klen;
+						_trans += (unsigned int)_klen;
+						break;
+					}
+					
+					_mid = _lower + ((_upper-_lower) >> 1);
+					if ( ( (*( p))) < (*( _mid)) )
+						_upper = _mid - 1;
+					else if ( ( (*( p))) > (*( _mid)) )
+						_lower = _mid + 1;
+					else {
+						_trans += (unsigned int)(_mid - _keys);
+						goto _match;
+					}
 				}
 			}
+			
+			_klen = (int)_sav_very_long_string_parse_range_lengths[cs];
+			if ( _klen > 0 ) {
+				const unsigned char *_lower = _keys;
+				const unsigned char *_upper = _keys + (_klen<<1) - 2;
+				const unsigned char *_mid;
+				while ( 1 ) {
+					if ( _upper < _lower ) {
+						_trans += (unsigned int)_klen;
+						break;
+					}
+					
+					_mid = _lower + (((_upper-_lower) >> 1) & ~1);
+					if ( ( (*( p))) < (*( _mid)) )
+						_upper = _mid - 2;
+					else if ( ( (*( p))) > (*( _mid + 1)) )
+						_lower = _mid + 2;
+					else {
+						_trans += (unsigned int)((_mid - _keys)>>1);
+						break;
+					}
+				}
+			}
+			
+			_match: {}
 		}
-		
-		_match: {}
 		cs = (int)_sav_very_long_string_parse_cond_targs[_trans];
 		
 		if ( _sav_very_long_string_parse_cond_actions[_trans] != 0 ) {
@@ -746,7 +759,7 @@ readstat_error_t sav_parse_very_long_string_record(void *data, int count, sav_ct
 							temp_key[str_len] = '\0';
 						}
 						
-#line 750 "src/spss/readstat_sav_parse.c"
+#line 763 "src/spss/readstat_sav_parse.c"
 						
 						break; 
 					}
@@ -755,7 +768,7 @@ readstat_error_t sav_parse_very_long_string_record(void *data, int count, sav_ct
 #line 20 "src/spss/readstat_sav_parse.rl"
 							str_start = p; }
 						
-#line 759 "src/spss/readstat_sav_parse.c"
+#line 772 "src/spss/readstat_sav_parse.c"
 						
 						break; 
 					}
@@ -764,13 +777,13 @@ readstat_error_t sav_parse_very_long_string_record(void *data, int count, sav_ct
 #line 20 "src/spss/readstat_sav_parse.rl"
 							str_len = p - str_start; }
 						
-#line 768 "src/spss/readstat_sav_parse.c"
+#line 781 "src/spss/readstat_sav_parse.c"
 						
 						break; 
 					}
 					case 3:  {
 						{
-#line 177 "src/spss/readstat_sav_parse.rl"
+#line 178 "src/spss/readstat_sav_parse.rl"
 							
 							varlookup_t *found = bsearch(temp_key, table, var_count, sizeof(varlookup_t), &compare_key_varlookup);
 							if (found) {
@@ -780,13 +793,13 @@ readstat_error_t sav_parse_very_long_string_record(void *data, int count, sav_ct
 							}
 						}
 						
-#line 784 "src/spss/readstat_sav_parse.c"
+#line 797 "src/spss/readstat_sav_parse.c"
 						
 						break; 
 					}
 					case 4:  {
 						{
-#line 186 "src/spss/readstat_sav_parse.rl"
+#line 187 "src/spss/readstat_sav_parse.rl"
 							
 							if ((( (*( p)))) != '\0') {
 								unsigned char digit = (( (*( p)))) - '0';
@@ -798,16 +811,16 @@ readstat_error_t sav_parse_very_long_string_record(void *data, int count, sav_ct
 							}
 						}
 						
-#line 802 "src/spss/readstat_sav_parse.c"
+#line 815 "src/spss/readstat_sav_parse.c"
 						
 						break; 
 					}
 					case 5:  {
 						{
-#line 197 "src/spss/readstat_sav_parse.rl"
+#line 198 "src/spss/readstat_sav_parse.rl"
 							temp_val = 0; }
 						
-#line 811 "src/spss/readstat_sav_parse.c"
+#line 824 "src/spss/readstat_sav_parse.c"
 						
 						break; 
 					}
@@ -818,20 +831,26 @@ readstat_error_t sav_parse_very_long_string_record(void *data, int count, sav_ct
 			
 		}
 		
-		if ( cs != 0 ) {
-			p += 1;
-			goto _resume;
+		if ( p == eof ) {
+			if ( cs >= 11 )
+				goto _out;
+		}
+		else {
+			if ( cs != 0 ) {
+				p += 1;
+				goto _resume;
+			}
 		}
 		_out: {}
 	}
 	
-#line 205 "src/spss/readstat_sav_parse.rl"
+#line 206 "src/spss/readstat_sav_parse.rl"
 	
 	
 	if (cs < 
-#line 833 "src/spss/readstat_sav_parse.c"
-	12
-#line 207 "src/spss/readstat_sav_parse.rl"
+#line 852 "src/spss/readstat_sav_parse.c"
+	11
+#line 208 "src/spss/readstat_sav_parse.rl"
 	|| p != pe) {
 		if (ctx->handle.error) {
 			snprintf(error_buf, error_buf_len, "Parsed %ld of %ld bytes. Remaining bytes: %.*s",

--- a/src/readstat/spss/readstat_sav_parse.rl
+++ b/src/readstat/spss/readstat_sav_parse.rl
@@ -166,6 +166,7 @@ readstat_error_t sav_parse_very_long_string_record(void *data, int count, sav_ct
     char *error_buf = NULL;
     unsigned char *p = c_data;
     unsigned char *pe = c_data + count;
+    unsigned char *eof = pe;
 
     varlookup_t *table = NULL;
     int cs;
@@ -198,7 +199,7 @@ readstat_error_t sav_parse_very_long_string_record(void *data, int count, sav_ct
         
         keyval = ( key %copy_key "=" value ) %set_width;
         
-        main := keyval ("\0"+ "\t" keyval)* "\0"+ "\t"?;
+        main := keyval ("\0"* "\t" keyval)* "\0"* "\t"?;
         
         write init;
         write exec;

--- a/src/readstat/spss/readstat_sav_read.c
+++ b/src/readstat/spss/readstat_sav_read.c
@@ -53,9 +53,9 @@ static readstat_charset_entry_t _charset_table[] = {
     { .code = 866,   .name = "CP866" },
     { .code = 869,   .name = "CP869" },
     { .code = 874,   .name = "CP874" },
-    { .code = 932,   .name = "SHIFT-JIS" },
-    { .code = 936,   .name = "ISO-IR-58" },
-    { .code = 949,   .name = "ISO-IR-149" },
+    { .code = 932,   .name = "CP932" },
+    { .code = 936,   .name = "CP936" },
+    { .code = 949,   .name = "CP949" },
     { .code = 950,   .name = "BIG-5" },
     { .code = 1200,  .name = "UTF-16LE" },
     { .code = 1201,  .name = "UTF-16BE" },
@@ -1620,8 +1620,8 @@ readstat_error_t readstat_parse_sav(readstat_parser_t *parser, const char *path,
         ctx->row_limit = parser->row_limit;
     }
     
-    if ((retval = sav_parse_timestamp(ctx, &header)) != READSTAT_OK)
-        goto cleanup;
+    /* ignore errors */
+    sav_parse_timestamp(ctx, &header);
 
     if ((retval = sav_parse_records_pass1(ctx)) != READSTAT_OK)
         goto cleanup;

--- a/src/readstat/stata/readstat_dta_write.c
+++ b/src/readstat/stata/readstat_dta_write.c
@@ -420,10 +420,10 @@ static readstat_error_t dta_emit_fmtlist(readstat_writer_t *writer, dta_ctx_t *c
             }
             char format[64];
             if (format_letter == 'g') {
-                sprintf(format, "%%%s%d.0g", r_variable->alignment == READSTAT_ALIGNMENT_LEFT ? "-" : "",
+                snprintf(format, sizeof(format), "%%%s%d.0g", r_variable->alignment == READSTAT_ALIGNMENT_LEFT ? "-" : "",
                         display_width);
             } else {
-                sprintf(format, "%%%s%ds",
+                snprintf(format, sizeof(format), "%%%s%ds",
                         r_variable->alignment == READSTAT_ALIGNMENT_LEFT ? "-" : "",
                         display_width);
             }

--- a/tests/testthat/_snaps/haven-spss.md
+++ b/tests/testthat/_snaps/haven-spss.md
@@ -41,11 +41,4 @@
       Error in `write_sav()`:
       ! Variables in `data` must have valid SPSS variable names.
       x Problems: `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` and `bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`
-    Code
-      names(df) <- c("流水号", "$性别", "年龄.")
-      write_sav(df, tempfile())
-    Condition
-      Error in `write_sav()`:
-      ! Variables in `data` must have valid SPSS variable names.
-      x Problems: `$性别` and `年龄.`
 

--- a/tests/testthat/test-haven-spss.R
+++ b/tests/testthat/test-haven-spss.R
@@ -351,18 +351,19 @@ test_that("complain about invalid variable names", {
       "c"
     )
     write_sav(df, tempfile())
-
-    names(df) <- c("流水号",  "$性别",  "年龄.")
-    write_sav(df, tempfile())
   })
 
   # Windows fails if this is a snapshot because of issues with unicode support
   expect_error(
     {
-      df <- data.frame(a = 1, A = 1)
+      df <- data.frame(a = 1, A = 1, b = 1)
+      names(df) <- c("流水号",  "$性别",  "年龄.")
+      write_sav(df, tempfile())
+
       names(df) <- c(
         paste(rep("\U044D", 33), collapse = ""),
-        paste(rep("\U767E", 22), collapse = "")
+        paste(rep("\U767E", 22), collapse = ""),
+        c
       )
       write_sav(df, tempfile())
     },


### PR DESCRIPTION
This update includes a heap of bug fixes:
* Fix various SAS catalog file reading bugs (fix #529, fix #653, fix #680, fix #696, fix #705).
* Increase maximum SAS page file size to 16MB (fix #697).
* Ignore invalid SAV timestamp strings (fix #683).
* Fix compiler warnings (fix #707).

Includes the ReadStat hacks:
* Windows iconv hack - c1f9f1997ad35e237629c5aba932a950caa79e1a
* Solaris hack - 4a878a10a290a164c24f30edfb7e5192b1f15b1d