### PR TITLE
Add `convert_utc` argument to writer functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,13 @@
 # haven (development version)
 
+* `write_*()` functions gain a new `convert_utc` argument to control timezone
+  conversion (#702) for date time variables. If `TRUE` (the default) date times
+  are converted to the equivalent UTC value and timezone is ignored, so they
+  will appear the same in R and Stata/SPSS/SAS. If `FALSE`, date time variables
+  are written as the corresponding UTC value.
+
 * Fixed issue in `write_*()` functions where invisible return of input data 
-  frame included unintended alteration of date/time variables. (@jmobrien, #702)
+  frame included unintended alteration of date time variables. (@jmobrien, #702)
 
 * The experimental `write_sas()` function has been deprecated (#224). The
   sas7bdat file format is complex and undocumented, and as such writing SAS

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,11 +7,20 @@
   * Ignore invalid SAV timestamp strings (#683).
   * Fix compiler warnings (#707).
 
-* `write_*()` functions gain a new `convert_utc` argument to control timezone
-  conversion (#702) for date time variables. If `TRUE` (the default) date times
-  are converted to the equivalent UTC value and timezone is ignored, so they
-  will appear the same in R and Stata/SPSS/SAS. If `FALSE`, date time variables
-  are written as the corresponding UTC value.
+* `write_*()` functions gain a new `adjust_tz` argument to allow more control
+  over time zone conversion for date-time variables (#702). Thanks to @jmobrien
+  for the detailed issue and feedback.
+  
+  Stata, SPSS and SAS do not have a concept of time zone. Since haven 2.4.0
+  date-time values in non-UTC time zones are implicitly converted when writing
+  to ensure the time displayed in Stata/SPSS/SAS will match the time displayed
+  to the user in R (see #555). This is the behaviour when `adjust_tz = TRUE`
+  (the default). Although this is in line with general user expectations it can
+  cause issues when the time zone is important, for e.g. when looking at
+  differences between time points, since the underlying numeric data is changed
+  to preserve the displayed time. Use `adjust_tz = FALSE` to write the time as
+  the corresponding UTC value, which will appear different to the user but
+  preserves the underlying numeric data.
 
 * Fixed issue in `write_*()` functions where invisible return of input data 
   frame included unintended alteration of date time variables. (@jmobrien, #702)

--- a/R/haven-sas.R
+++ b/R/haven-sas.R
@@ -134,11 +134,19 @@ read_xpt <- function(file, col_select = NULL, skip = 0, n_max = Inf, .name_repai
 #'
 #'   Note that although SAS itself supports dataset labels up to 256 characters
 #'   long, dataset labels in SAS transport files must be <= 40 characters.
-#' @param convert_utc If `TRUE` (the default), date times are converted to
-#'   the equivalent UTC value and timezone is ignored, so they will appear the
-#'   same in R and Stata/SPSS/SAS. If `FALSE`, date time variables are written
-#'   as the corresponding UTC value.
-write_xpt <- function(data, path, version = 8, name = NULL, label = attr(data, "label"), convert_utc = TRUE) {
+#' @param adjust_tz Stata, SPSS and SAS do not have a concept of time zone,
+#'   and all [date-time] variables are treated as UTC. `adjust_tz` controls
+#'   how the timezone of date-time values is treated when writing.
+#'
+#'   * If `TRUE` (the default) the timezone of date-time values is ignored, and
+#'   they will display the same in R and Stata/SPSS/SAS, e.g.
+#'   `"2010-01-01 09:00:00 NZDT"` will be written as `"2010-01-01 09:00:00"`.
+#'   Note that this changes the underlying numeric data, so use caution if
+#'   preserving between-time-point differences is critical.
+#'   * If `FALSE`, date-time values are written as the corresponding UTC value,
+#'   e.g. `"2010-01-01 09:00:00 NZDT"` will be written as
+#'   `"2009-12-31 20:00:00"`.
+write_xpt <- function(data, path, version = 8, name = NULL, label = attr(data, "label"), adjust_tz = TRUE) {
   if (!version %in% c(5, 8)) {
     cli_abort("SAS transport file version {.val {version}} is not currently supported.")
   }
@@ -151,7 +159,7 @@ write_xpt <- function(data, path, version = 8, name = NULL, label = attr(data, "
 
   data_out <- validate_sas(data)
 
-  if (isTRUE(convert_utc)) {
+  if (isTRUE(adjust_tz)) {
     data_out <- adjust_tz(data_out)
   }
 

--- a/R/haven-sas.R
+++ b/R/haven-sas.R
@@ -81,11 +81,11 @@ read_sas <- function(data_file, catalog_file = NULL,
 #' @export
 write_sas <- function(data, path) {
   lifecycle::deprecate_warn("2.6.0", "write_sas()", "write_xpt()")
-  
+
   validate_sas(data)
   data_out <- adjust_tz(data)
   write_sas_(data_out, normalizePath(path, mustWork = FALSE))
-  
+
   invisible(data)
 }
 
@@ -134,7 +134,11 @@ read_xpt <- function(file, col_select = NULL, skip = 0, n_max = Inf, .name_repai
 #'
 #'   Note that although SAS itself supports dataset labels up to 256 characters
 #'   long, dataset labels in SAS transport files must be <= 40 characters.
-write_xpt <- function(data, path, version = 8, name = NULL, label = attr(data, "label")) {
+#' @param convert_utc If `TRUE` (the default), date times are converted to
+#'   the equivalent UTC value and timezone is ignored, so they will appear the
+#'   same in R and Stata/SPSS/SAS. If `FALSE`, date time variables are written
+#'   as the corresponding UTC value.
+write_xpt <- function(data, path, version = 8, name = NULL, label = attr(data, "label"), convert_utc = TRUE) {
   if (!version %in% c(5, 8)) {
     cli_abort("SAS transport file version {.val {version}} is not currently supported.")
   }
@@ -145,8 +149,11 @@ write_xpt <- function(data, path, version = 8, name = NULL, label = attr(data, "
   name <- validate_xpt_name(name, version)
   label <- validate_xpt_label(label)
 
-  validate_sas(data)
-  data_out <- adjust_tz(data)
+  data_out <- validate_sas(data)
+
+  if (isTRUE(convert_utc)) {
+    data_out <- adjust_tz(data_out)
+  }
 
   write_xpt_(
     data_out,

--- a/R/haven-spss.R
+++ b/R/haven-spss.R
@@ -76,11 +76,19 @@ read_por <- function(file, user_na = FALSE, col_select = NULL, skip = 0, n_max =
 #'
 #'   `TRUE` and `FALSE` can be used for backwards compatibility, and correspond
 #'   to the "zsav" and "none" options respectively.
-#' @param convert_utc If `TRUE` (the default), date times are converted to
-#'   the equivalent UTC value and timezone is ignored, so they will appear the
-#'   same in R and Stata/SPSS/SAS. If `FALSE`, date time variables are written
-#'   as the corresponding UTC value.
-write_sav <- function(data, path, compress = c("byte", "none", "zsav"), convert_utc = TRUE) {
+#' @param adjust_tz Stata, SPSS and SAS do not have a concept of time zone,
+#'   and all [date-time] variables are treated as UTC. `adjust_tz` controls
+#'   how the timezone of date-time values is treated when writing.
+#'
+#'   * If `TRUE` (the default) the timezone of date-time values is ignored, and
+#'   they will display the same in R and Stata/SPSS/SAS, e.g.
+#'   `"2010-01-01 09:00:00 NZDT"` will be written as `"2010-01-01 09:00:00"`.
+#'   Note that this changes the underlying numeric data, so use caution if
+#'   preserving between-time-point differences is critical.
+#'   * If `FALSE`, date-time values are written as the corresponding UTC value,
+#'   e.g. `"2010-01-01 09:00:00 NZDT"` will be written as
+#'   `"2009-12-31 20:00:00"`.
+write_sav <- function(data, path, compress = c("byte", "none", "zsav"), adjust_tz = TRUE) {
   if (isTRUE(compress)) {
     compress <- "zsav"
   } else if (isFALSE(compress)) {
@@ -91,7 +99,7 @@ write_sav <- function(data, path, compress = c("byte", "none", "zsav"), convert_
 
   data_out <- validate_sav(data)
 
-  if (isTRUE(convert_utc)) {
+  if (isTRUE(adjust_tz)) {
     data_out <- adjust_tz(data_out)
   }
 

--- a/R/haven-spss.R
+++ b/R/haven-spss.R
@@ -76,7 +76,11 @@ read_por <- function(file, user_na = FALSE, col_select = NULL, skip = 0, n_max =
 #'
 #'   `TRUE` and `FALSE` can be used for backwards compatibility, and correspond
 #'   to the "zsav" and "none" options respectively.
-write_sav <- function(data, path, compress = c("byte", "none", "zsav")) {
+#' @param convert_utc If `TRUE` (the default), date times are converted to
+#'   the equivalent UTC value and timezone is ignored, so they will appear the
+#'   same in R and Stata/SPSS/SAS. If `FALSE`, date time variables are written
+#'   as the corresponding UTC value.
+write_sav <- function(data, path, compress = c("byte", "none", "zsav"), convert_utc = TRUE) {
   if (isTRUE(compress)) {
     compress <- "zsav"
   } else if (isFALSE(compress)) {
@@ -85,8 +89,12 @@ write_sav <- function(data, path, compress = c("byte", "none", "zsav")) {
     compress <- arg_match(compress)
   }
 
-  validate_sav(data)
-  data_out <- adjust_tz(data)
+  data_out <- validate_sav(data)
+
+  if (isTRUE(convert_utc)) {
+    data_out <- adjust_tz(data_out)
+  }
+
   write_sav_(data_out, normalizePath(path, mustWork = FALSE), compress = compress)
   invisible(data)
 }

--- a/R/haven-stata.R
+++ b/R/haven-stata.R
@@ -75,11 +75,18 @@ read_stata <- read_dta
 #'   2045, the maximum length of str# variables. See the Stata [long
 #'   string](https://www.stata.com/features/overview/long-strings/)
 #'   documentation for more details.
-write_dta <- function(data, path, version = 14, label = attr(data, "label"), strl_threshold = 2045) {
-  validate_dta(data, version = version)
+#' @param convert_utc If `TRUE` (the default), date times are converted to
+#'   the equivalent UTC value and timezone is ignored, so they will appear the
+#'   same in R and Stata/SPSS/SAS. If `FALSE`, date time variables are written
+#'   as the corresponding UTC value.
+write_dta <- function(data, path, version = 14, label = attr(data, "label"), strl_threshold = 2045, convert_utc = TRUE) {
+  data_out <- validate_dta(data, version = version)
   validate_dta_label(label)
 
-  data_out <- adjust_tz(data)
+  if (isTRUE(convert_utc)) {
+    data_out <- adjust_tz(data_out)
+  }
+
   write_dta_(
     data_out,
     normalizePath(path, mustWork = FALSE),

--- a/R/haven-stata.R
+++ b/R/haven-stata.R
@@ -75,15 +75,23 @@ read_stata <- read_dta
 #'   2045, the maximum length of str# variables. See the Stata [long
 #'   string](https://www.stata.com/features/overview/long-strings/)
 #'   documentation for more details.
-#' @param convert_utc If `TRUE` (the default), date times are converted to
-#'   the equivalent UTC value and timezone is ignored, so they will appear the
-#'   same in R and Stata/SPSS/SAS. If `FALSE`, date time variables are written
-#'   as the corresponding UTC value.
-write_dta <- function(data, path, version = 14, label = attr(data, "label"), strl_threshold = 2045, convert_utc = TRUE) {
+#' @param adjust_tz Stata, SPSS and SAS do not have a concept of time zone,
+#'   and all [date-time] variables are treated as UTC. `adjust_tz` controls
+#'   how the timezone of date-time values is treated when writing.
+#'
+#'   * If `TRUE` (the default) the timezone of date-time values is ignored, and
+#'   they will display the same in R and Stata/SPSS/SAS, e.g.
+#'   `"2010-01-01 09:00:00 NZDT"` will be written as `"2010-01-01 09:00:00"`.
+#'   Note that this changes the underlying numeric data, so use caution if
+#'   preserving between-time-point differences is critical.
+#'   * If `FALSE`, date-time values are written as the corresponding UTC value,
+#'   e.g. `"2010-01-01 09:00:00 NZDT"` will be written as
+#'   `"2009-12-31 20:00:00"`.
+write_dta <- function(data, path, version = 14, label = attr(data, "label"), strl_threshold = 2045, adjust_tz = TRUE) {
   data_out <- validate_dta(data, version = version)
   validate_dta_label(label)
 
-  if (isTRUE(convert_utc)) {
+  if (isTRUE(adjust_tz)) {
     data_out <- adjust_tz(data_out)
   }
 

--- a/man/read_dta.Rd
+++ b/man/read_dta.Rd
@@ -30,7 +30,7 @@ write_dta(
   version = 14,
   label = attr(data, "label"),
   strl_threshold = 2045,
-  convert_utc = TRUE
+  adjust_tz = TRUE
 )
 }
 \arguments{
@@ -94,10 +94,19 @@ of a standard string (str#) variable if \code{version} >= 13. This defaults to
 2045, the maximum length of str# variables. See the Stata \href{https://www.stata.com/features/overview/long-strings/}{long string}
 documentation for more details.}
 
-\item{convert_utc}{If \code{TRUE} (the default), date times are converted to
-the equivalent UTC value and timezone is ignored, so they will appear the
-same in R and Stata/SPSS/SAS. If \code{FALSE}, date time variables are written
-as the corresponding UTC value.}
+\item{adjust_tz}{Stata, SPSS and SAS do not have a concept of time zone,
+and all \link{date-time} variables are treated as UTC. \code{adjust_tz} controls
+how the timezone of date-time values is treated when writing.
+\itemize{
+\item If \code{TRUE} (the default) the timezone of date-time values is ignored, and
+they will display the same in R and Stata/SPSS/SAS, e.g.
+\code{"2010-01-01 09:00:00 NZDT"} will be written as \code{"2010-01-01 09:00:00"}.
+Note that this changes the underlying numeric data, so use caution if
+preserving between-time-point differences is critical.
+\item If \code{FALSE}, date-time values are written as the corresponding UTC value,
+e.g. \code{"2010-01-01 09:00:00 NZDT"} will be written as
+\code{"2009-12-31 20:00:00"}.
+}}
 }
 \value{
 A tibble, data frame variant with nice defaults.

--- a/man/read_dta.Rd
+++ b/man/read_dta.Rd
@@ -29,7 +29,8 @@ write_dta(
   path,
   version = 14,
   label = attr(data, "label"),
-  strl_threshold = 2045
+  strl_threshold = 2045,
+  convert_utc = TRUE
 )
 }
 \arguments{
@@ -92,6 +93,11 @@ than \code{strl_threshold} bytes will be stored as a long string (strL) instead
 of a standard string (str#) variable if \code{version} >= 13. This defaults to
 2045, the maximum length of str# variables. See the Stata \href{https://www.stata.com/features/overview/long-strings/}{long string}
 documentation for more details.}
+
+\item{convert_utc}{If \code{TRUE} (the default), date times are converted to
+the equivalent UTC value and timezone is ignored, so they will appear the
+same in R and Stata/SPSS/SAS. If \code{FALSE}, date time variables are written
+as the corresponding UTC value.}
 }
 \value{
 A tibble, data frame variant with nice defaults.

--- a/man/read_spss.Rd
+++ b/man/read_spss.Rd
@@ -26,7 +26,7 @@ read_por(
   .name_repair = "unique"
 )
 
-write_sav(data, path, compress = c("byte", "none", "zsav"))
+write_sav(data, path, compress = c("byte", "none", "zsav"), convert_utc = TRUE)
 
 read_spss(
   file,
@@ -102,6 +102,11 @@ compression is supported by SPSS version 21.0 and above.
 
 \code{TRUE} and \code{FALSE} can be used for backwards compatibility, and correspond
 to the "zsav" and "none" options respectively.}
+
+\item{convert_utc}{If \code{TRUE} (the default), date times are converted to
+the equivalent UTC value and timezone is ignored, so they will appear the
+same in R and Stata/SPSS/SAS. If \code{FALSE}, date time variables are written
+as the corresponding UTC value.}
 }
 \value{
 A tibble, data frame variant with nice defaults.

--- a/man/read_spss.Rd
+++ b/man/read_spss.Rd
@@ -26,7 +26,7 @@ read_por(
   .name_repair = "unique"
 )
 
-write_sav(data, path, compress = c("byte", "none", "zsav"), convert_utc = TRUE)
+write_sav(data, path, compress = c("byte", "none", "zsav"), adjust_tz = TRUE)
 
 read_spss(
   file,
@@ -103,10 +103,19 @@ compression is supported by SPSS version 21.0 and above.
 \code{TRUE} and \code{FALSE} can be used for backwards compatibility, and correspond
 to the "zsav" and "none" options respectively.}
 
-\item{convert_utc}{If \code{TRUE} (the default), date times are converted to
-the equivalent UTC value and timezone is ignored, so they will appear the
-same in R and Stata/SPSS/SAS. If \code{FALSE}, date time variables are written
-as the corresponding UTC value.}
+\item{adjust_tz}{Stata, SPSS and SAS do not have a concept of time zone,
+and all \link{date-time} variables are treated as UTC. \code{adjust_tz} controls
+how the timezone of date-time values is treated when writing.
+\itemize{
+\item If \code{TRUE} (the default) the timezone of date-time values is ignored, and
+they will display the same in R and Stata/SPSS/SAS, e.g.
+\code{"2010-01-01 09:00:00 NZDT"} will be written as \code{"2010-01-01 09:00:00"}.
+Note that this changes the underlying numeric data, so use caution if
+preserving between-time-point differences is critical.
+\item If \code{FALSE}, date-time values are written as the corresponding UTC value,
+e.g. \code{"2010-01-01 09:00:00 NZDT"} will be written as
+\code{"2009-12-31 20:00:00"}.
+}}
 }
 \value{
 A tibble, data frame variant with nice defaults.

--- a/man/read_xpt.Rd
+++ b/man/read_xpt.Rd
@@ -13,7 +13,14 @@ read_xpt(
   .name_repair = "unique"
 )
 
-write_xpt(data, path, version = 8, name = NULL, label = attr(data, "label"))
+write_xpt(
+  data,
+  path,
+  version = 8,
+  name = NULL,
+  label = attr(data, "label"),
+  convert_utc = TRUE
+)
 }
 \arguments{
 \item{file}{Either a path to a file, a connection, or literal data
@@ -72,6 +79,11 @@ the "label" attribute of \code{data}.
 
 Note that although SAS itself supports dataset labels up to 256 characters
 long, dataset labels in SAS transport files must be <= 40 characters.}
+
+\item{convert_utc}{If \code{TRUE} (the default), date times are converted to
+the equivalent UTC value and timezone is ignored, so they will appear the
+same in R and Stata/SPSS/SAS. If \code{FALSE}, date time variables are written
+as the corresponding UTC value.}
 }
 \value{
 A tibble, data frame variant with nice defaults.

--- a/man/read_xpt.Rd
+++ b/man/read_xpt.Rd
@@ -19,7 +19,7 @@ write_xpt(
   version = 8,
   name = NULL,
   label = attr(data, "label"),
-  convert_utc = TRUE
+  adjust_tz = TRUE
 )
 }
 \arguments{
@@ -80,10 +80,19 @@ the "label" attribute of \code{data}.
 Note that although SAS itself supports dataset labels up to 256 characters
 long, dataset labels in SAS transport files must be <= 40 characters.}
 
-\item{convert_utc}{If \code{TRUE} (the default), date times are converted to
-the equivalent UTC value and timezone is ignored, so they will appear the
-same in R and Stata/SPSS/SAS. If \code{FALSE}, date time variables are written
-as the corresponding UTC value.}
+\item{adjust_tz}{Stata, SPSS and SAS do not have a concept of time zone,
+and all \link{date-time} variables are treated as UTC. \code{adjust_tz} controls
+how the timezone of date-time values is treated when writing.
+\itemize{
+\item If \code{TRUE} (the default) the timezone of date-time values is ignored, and
+they will display the same in R and Stata/SPSS/SAS, e.g.
+\code{"2010-01-01 09:00:00 NZDT"} will be written as \code{"2010-01-01 09:00:00"}.
+Note that this changes the underlying numeric data, so use caution if
+preserving between-time-point differences is critical.
+\item If \code{FALSE}, date-time values are written as the corresponding UTC value,
+e.g. \code{"2010-01-01 09:00:00 NZDT"} will be written as
+\code{"2009-12-31 20:00:00"}.
+}}
 }
 \value{
 A tibble, data frame variant with nice defaults.

--- a/tests/testthat/test-haven-sas.R
+++ b/tests/testthat/test-haven-sas.R
@@ -180,7 +180,7 @@ test_that("can roundtrip date times", {
   x2_utc <- x2
   attr(x2_utc, "tzone") <- "UTC"
   expect_equal(
-    roundtrip_var(x2, "xpt", convert_utc = FALSE),
+    roundtrip_var(x2, "xpt", adjust_tz = FALSE),
     x2_utc
   )
 

--- a/tests/testthat/test-haven-sas.R
+++ b/tests/testthat/test-haven-sas.R
@@ -166,6 +166,28 @@ test_that("can roundtrip missing values (as much as possible)", {
   expect_equal(roundtrip_var(NA_character_, "xpt"), "")
 })
 
+test_that("can roundtrip date times", {
+  x1 <- c(as.Date("2010-01-01"), NA)
+  expect_equal(roundtrip_var(x1, "xpt"), x1)
+
+  # converted to same time in UTC
+  x2 <- as.POSIXct("2010-01-01 09:00", tz = "Pacific/Auckland")
+  expect_equal(
+    roundtrip_var(x2, "xpt"),
+    as.POSIXct("2010-01-01 09:00", tz = "UTC")
+  )
+
+  x2_utc <- x2
+  attr(x2_utc, "tzone") <- "UTC"
+  expect_equal(
+    roundtrip_var(x2, "xpt", convert_utc = FALSE),
+    x2_utc
+  )
+
+  attr(x2, "label") <- "abc"
+  expect_equal(attr(roundtrip_var(x2, "xpt"), "label"), "abc")
+})
+
 test_that("invalid files generate informative errors", {
   expect_snapshot(error = TRUE, {
     write_xpt(mtcars, file.path(tempdir(), " temp.xpt"))

--- a/tests/testthat/test-haven-spss.R
+++ b/tests/testthat/test-haven-spss.R
@@ -178,7 +178,7 @@ test_that("can roundtrip date times", {
   x2_utc <- x2
   attr(x2_utc, "tzone") <- "UTC"
   expect_equal(
-    roundtrip_var(x2, "sav", convert_utc = FALSE),
+    roundtrip_var(x2, "sav", adjust_tz = FALSE),
     x2_utc
   )
 

--- a/tests/testthat/test-haven-spss.R
+++ b/tests/testthat/test-haven-spss.R
@@ -175,6 +175,13 @@ test_that("can roundtrip date times", {
     as.POSIXct("2010-01-01 09:00", tz = "UTC")
   )
 
+  x2_utc <- x2
+  attr(x2_utc, "tzone") <- "UTC"
+  expect_equal(
+    roundtrip_var(x2, "sav", convert_utc = FALSE),
+    x2_utc
+  )
+
   attr(x2, "label") <- "abc"
   expect_equal(attr(roundtrip_var(x2, "sav"), "label"), "abc")
 })

--- a/tests/testthat/test-haven-stata.R
+++ b/tests/testthat/test-haven-stata.R
@@ -115,6 +115,13 @@ test_that("can roundtrip date times", {
     as.POSIXct("2010-01-01 09:00", tz = "UTC")
   )
 
+  x2_utc <- x2
+  attr(x2_utc, "tzone") <- "UTC"
+  expect_equal(
+    roundtrip_var(x2, "sav", convert_utc = FALSE),
+    x2_utc
+  )
+
   attr(x2, "label") <- "abc"
   expect_equal(attr(roundtrip_var(x2, "dta"), "label"), "abc")
 })

--- a/tests/testthat/test-haven-stata.R
+++ b/tests/testthat/test-haven-stata.R
@@ -118,7 +118,7 @@ test_that("can roundtrip date times", {
   x2_utc <- x2
   attr(x2_utc, "tzone") <- "UTC"
   expect_equal(
-    roundtrip_var(x2, "sav", convert_utc = FALSE),
+    roundtrip_var(x2, "sav", adjust_tz = FALSE),
     x2_utc
   )
 


### PR DESCRIPTION
Close #702.

@jmobrien do you have any feedback on the docs? I'm not entirely sure that this makes sense :sweat_smile: 

> If `TRUE` (the default) date times are converted to the equivalent UTC value and timezone is ignored, so they will appear the same in R and Stata/SPSS/SAS. If `FALSE`, date time variables are written as the corresponding UTC value.