### PR TITLE
add creation/modified time/file encoding to attr

### DIFF
--- a/src/DfReader.cpp
+++ b/src/DfReader.cpp
@@ -183,6 +183,17 @@ public:
     }
   }
 
+  void setTimestamp(time_t c_time, time_t m_time) {
+    output_.attr("creation_timestamp") = c_time;
+    output_.attr("modified_timestamp") = m_time;
+  }
+
+  void setFileEncoding(const char *file_encoding) {
+    if (file_encoding != NULL && strcmp(file_encoding, "") != 0) {
+      output_.attr("encoding") = file_encoding;
+    }
+  }
+
   void setNote(int note_index, const char *note) {
     if (note != NULL && strcmp(note, "") != 0) {
       notes_.push_back(note);
@@ -469,6 +480,8 @@ int dfreader_metadata(readstat_metadata_t *metadata, void *ctx) {
       readstat_get_var_count(metadata)
   );
   ((DfReader*) ctx)->setMetadata(readstat_get_file_label(metadata));
+  ((DfReader*) ctx)->setFileEncoding(readstat_get_file_encoding(metadata));
+  ((DfReader*) ctx)->setTimestamp(readstat_get_creation_time(metadata), readstat_get_modified_time(metadata));
   return 0;
 }
 


### PR DESCRIPTION
As described [herer](https://github.com/tidyverse/haven/issues/732), this PR is about to:

1. Expose` readstat_get_creation_time`/`readstat_get_modified_time`/`readstat_get_file_encoding` to `haven`
2. Set `creation_timestamp`/`modified_timestamp`/`encoding` to the attribute of the output dataset