### PR TITLE
Remove write_sas mention from read_sas doc

### DIFF
--- a/R/haven-sas.R
+++ b/R/haven-sas.R
@@ -23,7 +23,6 @@
 #'   Variable labels are stored in the "label" attribute of each variable. It is
 #'   not printed on the console, but the RStudio viewer will show it.
 #'
-#'   `write_sas()` returns the input `data` invisibly.
 #' @export
 #' @examples
 #' path <- system.file("examples", "iris.sas7bdat", package = "haven")

--- a/man/as_factor.Rd
+++ b/man/as_factor.Rd
@@ -36,7 +36,7 @@
 Labels are sorted by value.
 \item "both": like "default", but pastes together the level and value
 \item "label": use only the labels; unlabelled values become \code{NA}
-\item "values: use only the values
+\item "values": use only the values
 }}
 
 \item{ordered}{If \code{TRUE} create an ordered (ordinal) factor, if

--- a/man/read_sas.Rd
+++ b/man/read_sas.Rd
@@ -58,8 +58,6 @@ A tibble, data frame variant with nice defaults.
 
 Variable labels are stored in the "label" attribute of each variable. It is
 not printed on the console, but the RStudio viewer will show it.
-
-\code{write_sas()} returns the input \code{data} invisibly.
 }
 \description{
 \code{read_sas()} supports both sas7bdat files and the accompanying sas7bcat files

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -110,9 +110,9 @@ extern "C" SEXP _haven_write_xpt_(SEXP data, SEXP path, SEXP version, SEXP name,
 
 extern "C" {
 /* .Call calls */
-extern SEXP is_tagged_na_(void *, void *);
-extern SEXP na_tag_(void *);
-extern SEXP tagged_na_(void *);
+extern SEXP is_tagged_na_(SEXP, SEXP);
+extern SEXP na_tag_(SEXP);
+extern SEXP tagged_na_(SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
     {"_haven_df_parse_dta_file", (DL_FUNC) &_haven_df_parse_dta_file, 6},


### PR DESCRIPTION
This addresses #766 

Note that while updating documentation with `devtools::document()` a few other unrelated files were changed as documentation must not have been run since some other changes had been made.