### PR TITLE
Clarify labelled vectors in read docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # haven (development version)
 
+* Documentation for `read_*()` functions now more clearly explains that
+  labelled vectors are an intermediate representation, and points users to
+  `as_factor()` and `zap_labels()` when preparing imported categorical
+  variables for analysis (#741).
+
 * `col_select` in the `read_*()` functions now correctly implements the
   tidyselect interface. Columns will be returned in the order specified in
   `col_select` and can be renamed, e.g. `col_select = c(new = old)` (#685).

--- a/R/haven-sas.R
+++ b/R/haven-sas.R
@@ -27,6 +27,13 @@
 #'   Variable labels are stored in the "label" attribute of each variable. It is
 #'   not printed on the console, but the RStudio viewer will show it.
 #'
+#'   Value labels from a catalog file are preserved with the [labelled()] class.
+#'   Labelled vectors are an intermediate representation that preserves the
+#'   original value labels, not a regular R factor. Convert labelled categorical
+#'   variables with [as_factor()], or remove value labels with [zap_labels()] if
+#'   you need plain R vectors for analysis. See `vignette("semantics")` for more
+#'   details.
+#'
 #' @export
 #' @examples
 #' path <- system.file("examples", "iris.sas7bdat", package = "haven")

--- a/R/haven-spss.R
+++ b/R/haven-spss.R
@@ -21,6 +21,13 @@
 #'   Variable labels are stored in the "label" attribute of each variable.
 #'   It is not printed on the console, but the RStudio viewer will show it.
 #'
+#'   Value labels are preserved with the [labelled()] class, or
+#'   [labelled_spss()] when `user_na = TRUE`. Labelled vectors are an
+#'   intermediate representation that preserves the original value labels, not a
+#'   regular R factor. Convert labelled categorical variables with [as_factor()],
+#'   or remove value labels with [zap_labels()] if you need plain R vectors for
+#'   analysis. See `vignette("semantics")` for more details.
+#'
 #'   `write_sav()` returns the input `data` invisibly.
 #' @name read_spss
 #' @examples

--- a/R/haven-stata.R
+++ b/R/haven-stata.R
@@ -59,6 +59,12 @@
 #'   Variable labels are stored in the "label" attribute of each variable.
 #'   It is not printed on the console, but the RStudio viewer will show it.
 #'
+#'   Value labels are preserved with the [labelled()] class. Labelled vectors are
+#'   an intermediate representation that preserves the original value labels,
+#'   not a regular R factor. Convert labelled categorical variables with
+#'   [as_factor()], or remove value labels with [zap_labels()] if you need plain
+#'   R vectors for analysis. See `vignette("semantics")` for more details.
+#'
 #'   If a dataset label is defined in Stata, it will stored in the "label"
 #'   attribute of the tibble.
 #'

--- a/man/read_dta.Rd
+++ b/man/read_dta.Rd
@@ -121,6 +121,12 @@ A tibble, data frame variant with nice defaults.
 Variable labels are stored in the "label" attribute of each variable.
 It is not printed on the console, but the RStudio viewer will show it.
 
+Value labels are preserved with the \code{\link[=labelled]{labelled()}} class. Labelled vectors are
+an intermediate representation that preserves the original value labels,
+not a regular R factor. Convert labelled categorical variables with
+\code{\link[=as_factor]{as_factor()}}, or remove value labels with \code{\link[=zap_labels]{zap_labels()}} if you need plain
+R vectors for analysis. See \code{vignette("semantics")} for more details.
+
 If a dataset label is defined in Stata, it will stored in the "label"
 attribute of the tibble.
 

--- a/man/read_sas.Rd
+++ b/man/read_sas.Rd
@@ -64,6 +64,13 @@ A tibble, data frame variant with nice defaults.
 
 Variable labels are stored in the "label" attribute of each variable. It is
 not printed on the console, but the RStudio viewer will show it.
+
+Value labels from a catalog file are preserved with the \code{\link[=labelled]{labelled()}} class.
+Labelled vectors are an intermediate representation that preserves the
+original value labels, not a regular R factor. Convert labelled categorical
+variables with \code{\link[=as_factor]{as_factor()}}, or remove value labels with \code{\link[=zap_labels]{zap_labels()}} if
+you need plain R vectors for analysis. See \code{vignette("semantics")} for more
+details.
 }
 \description{
 \code{read_sas()} supports both sas7bdat files and the accompanying sas7bcat files

--- a/man/read_spss.Rd
+++ b/man/read_spss.Rd
@@ -129,6 +129,13 @@ A tibble, data frame variant with nice defaults.
 Variable labels are stored in the "label" attribute of each variable.
 It is not printed on the console, but the RStudio viewer will show it.
 
+Value labels are preserved with the \code{\link[=labelled]{labelled()}} class, or
+\code{\link[=labelled_spss]{labelled_spss()}} when \code{user_na = TRUE}. Labelled vectors are an
+intermediate representation that preserves the original value labels, not a
+regular R factor. Convert labelled categorical variables with \code{\link[=as_factor]{as_factor()}},
+or remove value labels with \code{\link[=zap_labels]{zap_labels()}} if you need plain R vectors for
+analysis. See \code{vignette("semantics")} for more details.
+
 \code{write_sav()} returns the input \code{data} invisibly.
 }
 \description{


### PR DESCRIPTION
Fixes #741.

This updates the `read_*()` documentation to make the imported labelled-vector workflow more explicit for users coming from Stata, SPSS, or SAS:

- notes that value labels are preserved as `labelled()` / `labelled_spss()` intermediate representations, not regular R factors
- points users to `as_factor()` for labelled categorical variables
- points users to `zap_labels()` when plain R vectors are needed for analysis
- updates the generated Rd files and NEWS entry alongside the roxygen source

I kept this as a documentation-only change and did not add a runtime message, following the maintainer preference in #741.

Checks run locally:

- `tools::checkRd()` for `man/read_dta.Rd`, `man/read_spss.Rd`, and `man/read_sas.Rd`
- `git diff --check`
- `R CMD build --no-build-vignettes .`
- `_R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual --ignore-vignettes --no-build-vignettes --no-tests haven_2.5.5.9000.tar.gz`

The local machine does not currently have suggested packages `testthat` and `covr`, so I could not run the full test suite locally. The no-tests check installs the package, checks Rd/examples, and completes with one existing NOTE about `setNames` that is unrelated to this documentation change.