### PR TITLE
test: add test for format.sas trailing period stripping in XPT roundtrip

### DIFF
--- a/tests/testthat/test-haven-sas.R
+++ b/tests/testthat/test-haven-sas.R
@@ -304,6 +304,21 @@ test_that("can roundtrip format attribute", {
   expect_identical(df, out)
 })
 
+test_that("trailing period in format.sas is stripped during roundtrip", {
+  df <- tibble(
+    date_var = structure(as.Date("2025-01-02"), format.sas = "DATE9."),
+    num_var = structure(100.12345, format.sas = "BEST12.")
+  )
+
+  path <- tempfile()
+  write_xpt(df, path)
+  out <- read_xpt(path)
+
+  # SAS transport format does not store trailing periods
+  expect_equal(attr(out$date_var, "format.sas"), "DATE9")
+  expect_equal(attr(out$num_var, "format.sas"), "BEST12")
+})
+
 test_that("user width warns appropriately when data is wider than value", {
   df <- tibble(
     a = c("a", NA_character_),


### PR DESCRIPTION
Adds a test that explicitly verifies the trailing period stripping behavior documented in PR #801.

The SAS transport format does not store trailing periods in format names (e.g., "DATE9." becomes "DATE9"). This test confirms that write_xpt() to read_xpt() correctly strips trailing periods from format.sas attributes.

This test complements the existing "can roundtrip format attribute" test, which only uses formats without trailing periods.

Checks run locally:
- devtools::test(filter = "haven-sas") - all 73 tests pass
- Full test suite: 1 pre-existing snapshot failure in test-labelled-pillar.R (Unicode encoding), unrelated to this change