### PR TITLE
fix: test-zap_label uses zap_labels, vignette typo, read_sas doc param ref

### DIFF
--- a/R/haven-sas.R
+++ b/R/haven-sas.R
@@ -6,7 +6,7 @@
 #' @param data_file,catalog_file Path to data and catalog files. The files are
 #'   processed with [readr::datasource()].
 #' @param encoding,catalog_encoding The character encoding used for the
-#'   `data_file` and `catalog_encoding` respectively. A value of `NULL` uses the
+#'   `data_file` and `catalog_file` respectively. A value of `NULL` uses the
 #'   encoding specified in the file; use this argument to override it if it is
 #'   incorrect.
 #' @inheritParams tibble::as_tibble

--- a/tests/testthat/test-zap_label.R
+++ b/tests/testthat/test-zap_label.R
@@ -6,7 +6,7 @@ test_that("zap_label strips label but doesn't change other attributes", {
 
 test_that("zap_label returns variables not of class('labelled') unmodified", {
   var <- c(1L, 98L, 99L)
-  expect_equal(zap_labels(var), var)
+  expect_equal(zap_label(var), var)
 })
 
 test_that("zap_label is correctly applied to every column in data frame", {

--- a/vignettes/semantics.Rmd
+++ b/vignettes/semantics.Rmd
@@ -28,7 +28,7 @@ Base R has one data type that effectively maintains a mapping between integers a
   special missing values (e.g. `.D` = did not respond, `.N` = 
   not applicable), while leaving other values as is.
 
-Value labels in SAS are a little different again. In SAS, labels are just special case of general formats. Formats include currencies and dates, but user-defined just assigns labels to individual values (including special missings value). Formats have names and existing independently of the variables they are associated with. You create a named format with `PROC FORMAT` and then associated with variables in a `DATA` step (the names of character formats thealways start with `$`). 
+Value labels in SAS are a little different again. In SAS, labels are just special case of general formats. Formats include currencies and dates, but user-defined just assigns labels to individual values (including special missings value). Formats have names and existing independently of the variables they are associated with. You create a named format with `PROC FORMAT` and then associated with variables in a `DATA` step (the names of character formats they always start with `$`). 
 
 ### `labelled()`
 


### PR DESCRIPTION
Three small fixes:

1. **test-zap_label.R**: Fix copy-paste error — test "zap_label returns variables not of class('labelled') unmodified" was calling `zap_labels()` (plural) instead of `zap_label()` (singular). The test passed either way since `zap_labels.default` also returns `x` unchanged, but the test wasn't exercising the function it claimed to test.

2. **vignettes/semantics.Rmd**: Fix typo "thealways" → "they always" in the SAS value labels section.

3. **R/haven-sas.R**: Fix `@param` description for `read_sas()` — the `encoding,catalog_encoding` description referenced "catalog_encoding" where it should say "catalog_file".

All existing tests pass.
