### PR TITLE
fix: correct na_value typo to na_values in docs

### DIFF
--- a/R/zap_missing.R
+++ b/R/zap_missing.R
@@ -16,7 +16,7 @@
 #' x2 <- labelled_spss(
 #'   c(1, 2, 1, 99),
 #'   c(missing = 99),
-#'   na_value = 99
+#'   na_values = 99
 #' )
 #' x2
 #' zap_missing(x2)

--- a/vignettes/semantics.Rmd
+++ b/vignettes/semantics.Rmd
@@ -134,7 +134,7 @@ as_factor(y)
 SPSS's user-defined values work differently to SAS and Stata. Each column can have either up to three distinct values that are considered as missing, or a range.  Haven provides `labelled_spss()` as a subclass of `labelled()` to model these additional user-defined missings. 
 
 ```{r}
-x1 <- labelled_spss(c(1:10, 99), c(Missing = 99), na_value = 99)
+x1 <- labelled_spss(c(1:10, 99), c(Missing = 99), na_values = 99)
 x2 <- labelled_spss(c(1:10, 99), c(Missing = 99), na_range = c(90, Inf))
 
 x1


### PR DESCRIPTION
## Summary

Fixes a typo in documentation where `na_value` (without 's') was used instead of the correct parameter name `na_values`.

## Changes

- `R/zap_missing.R`: Fixed roxygen example for `zap_missing()` 
- `vignettes/semantics.Rmd`: Fixed SPSS user-defined missing values section

## Details

The `labelled_spss()` function parameter is named `na_values` (with 's'), not `na_value`. While R's partial argument matching makes the examples work correctly, the incorrect parameter name in documentation could confuse users reading the source code.

## Testing

- `devtools::test(filter = "zap_missing")`: PASS (8 tests)
- All existing tests pass

## Related

No related issues found.