### PR TITLE
test: expand zap_empty() test coverage

### DIFF
--- a/tests/testthat/test-zap-empty.R
+++ b/tests/testthat/test-zap-empty.R
@@ -2,3 +2,32 @@ test_that("empty strings replaced with missing", {
   x <- c("", "a", NA)
   expect_equal(zap_empty(x), c(NA, "a", NA))
 })
+
+test_that("errors on non-character input", {
+  expect_error(zap_empty(1:5))
+  expect_error(zap_empty(factor("a")))
+  expect_error(zap_empty(TRUE))
+})
+
+test_that("all empty strings become NA", {
+  x <- c("", "", "")
+  result <- zap_empty(x)
+  expect_equal(length(result), 3)
+  expect_true(all(is.na(result)))
+  expect_type(result, "character")
+})
+
+test_that("no empty strings returns unchanged", {
+  x <- c("a", "b", "c")
+  expect_equal(zap_empty(x), x)
+})
+
+test_that("preserves existing NAs", {
+  x <- c("", NA, "a", "", NA)
+  expect_equal(zap_empty(x), c(NA, NA, "a", NA, NA))
+})
+
+test_that("works with empty input", {
+  x <- character(0)
+  expect_equal(zap_empty(x), x)
+})


### PR DESCRIPTION
## Summary

Expand test coverage for `zap_empty()` from 1 test to 6 tests, covering edge cases and input validation.

## Changes

- **`tests/testthat/test-zap-empty.R`**: Added 5 new tests:
  - Error on non-character input (numeric, factor, logical)
  - All empty strings become NA
  - No empty strings returns unchanged
  - Preserves existing NAs
  - Works with empty input (`character(0)`)

## Testing

- `devtools::test(filter = "zap-empty")`: All 6 tests pass
- Full suite: 475 pass, 1 pre-existing snapshot failure (Unicode in `test-labelled-pillar.R`), unrelated

## Related

No related issues or PRs found for `zap_empty()` test coverage.