### PR TITLE
test: add na_range coverage for zap_labels() on labelled_spss

### DIFF
--- a/tests/testthat/test-zap_labels.R
+++ b/tests/testthat/test-zap_labels.R
@@ -26,3 +26,24 @@ test_that("keeps user-defined missings for spss if user_na = TRUE", {
   df <- tibble::tibble(x = 1:10, y = labelled_spss(10:1, c("good" = 1), na_values = 10))
   expect_equal(zap_labels(df, user_na = TRUE)$y, 10:1)
 })
+
+test_that("replaces na_range missings for spss", {
+  x <- labelled_spss(1:10, c(low = 1), na_range = c(8, 10))
+  out <- zap_labels(x)
+  expect_equal(out[1:7], 1:7)
+  expect_true(all(is.na(out[8:10])))
+})
+
+test_that("replaces na_range and na_values missings for spss", {
+  x <- labelled_spss(1:10, c(low = 1), na_values = 5, na_range = c(8, 10))
+  out <- zap_labels(x)
+  expect_true(is.na(out[5]))
+  expect_true(all(is.na(out[8:10])))
+  expect_equal(out[c(1:4, 6:7)], c(1:4, 6:7))
+})
+
+test_that("keeps na_range missings for spss if user_na = TRUE", {
+  x <- labelled_spss(1:10, c(low = 1), na_range = c(8, 10))
+  out <- zap_labels(x, user_na = TRUE)
+  expect_equal(out, 1:10)
+})


### PR DESCRIPTION
## What

Adds 3 test cases for `zap_labels()` with `na_range` on `labelled_spss` objects. The existing tests only covered `na_values`.

## Tests added

1. **na_range values replaced with NA** — verifies `zap_labels()` correctly converts values in `na_range` to `NA` (default `user_na = FALSE`).
2. **na_range and na_values together** — verifies both mechanisms work correctly on the same vector.
3. **na_range preserved with user_na = TRUE** — verifies `na_range` values are kept as-is when `user_na = TRUE`.

## Validation

- `devtools::test(filter = "zap_labels")` — 12/12 pass (5 existing + 3 new)
- Full suite passes (no regressions)

## Why

`zap_labels.haven_labelled_spss` strips both `na_values` and `na_range` attributes and converts user-defined missings to `NA`. The existing tests only verified `na_range` removal indirectly at best (via `zap_missing` tests). This adds direct test coverage for the `na_range` path.
