### PR TITLE
test: expand zap_widths() test coverage

### DIFF
--- a/tests/testthat/test-zap_widths.R
+++ b/tests/testthat/test-zap_widths.R
@@ -12,3 +12,54 @@ test_that("can zap width attribute from vector in data frame", {
 
   expect_null(attributes(out$x))
 })
+
+test_that("zap_widths removes display_width from labelled vector", {
+  x <- labelled(1:5, c(good = 1, bad = 5))
+  attr(x, "display_width") <- 10
+  out <- zap_widths(x)
+
+  expect_null(attr(out, "display_width"))
+  expect_s3_class(out, "haven_labelled")
+  expect_equal(attr(out, "labels"), c(good = 1, bad = 5))
+})
+
+test_that("zap_widths removes display_width from labelled_spss vector", {
+  x <- labelled_spss(1:5, c(good = 1), na_values = 5)
+  attr(x, "display_width") <- 10
+  out <- zap_widths(x)
+
+  expect_null(attr(out, "display_width"))
+  expect_s3_class(out, "haven_labelled_spss")
+  expect_equal(attr(out, "na_values"), 5)
+})
+
+test_that("zap_widths preserves other attributes", {
+  x <- structure(1:5, display_width = 10, format.spss = "F8.2", label = "myvar")
+  out <- zap_widths(x)
+
+  expect_null(attr(out, "display_width"))
+  expect_equal(attr(out, "format.spss"), "F8.2")
+  expect_equal(attr(out, "label"), "myvar")
+})
+
+test_that("zap_widths works with data frame containing multiple columns", {
+  df <- tibble::tibble(
+    a = structure(1:3, display_width = 10),
+    b = structure(4:6, display_width = 20, label = "var b"),
+    c = 7:9
+  )
+  out <- zap_widths(df)
+
+  expect_null(attr(out$a, "display_width"))
+  expect_null(attr(out$b, "display_width"))
+  expect_equal(attr(out$b, "label"), "var b")
+  expect_equal(out$c, 7:9)
+})
+
+test_that("zap_widths preserves existing NAs", {
+  x <- structure(c(1, NA, 3), display_width = 10)
+  out <- zap_widths(x)
+
+  expect_null(attr(out, "display_width"))
+  expect_equal(out, c(1, NA, 3))
+})


### PR DESCRIPTION
## Summary

This PR expands test coverage for `zap_widths()`, which removes the `display_width` attribute from vectors. The function had only 2 tests covering basic cases. This PR adds 5 new tests covering edge cases and attribute preservation, bringing the total to 7 tests.

### Tests added

- **Labelled vectors**: verifies class and `labels` attribute are preserved
- **labelled_spss vectors**: verifies `na_values` attribute is preserved
- **Attribute preservation**: verifies `format.spss` and `label` attributes remain after zapping widths
- **Multi-column data frames**: verifies widths are removed from all columns
- **NA preservation**: verifies existing NAs are not affected

## Validation

- `devtools::test(filter = "zap-widths")` — all 7 tests pass
- Full test suite passes (pre-existing Unicode snapshot failure in `test-labelled-pillar.R`, unrelated)