### PR TITLE
docs: fix two typos in semantics.Rmd vignette

### DIFF
--- a/tests/testthat/test-zap_labels.R
+++ b/tests/testthat/test-zap_labels.R
@@ -26,3 +26,24 @@ test_that("keeps user-defined missings for spss if user_na = TRUE", {
   df <- tibble::tibble(x = 1:10, y = labelled_spss(10:1, c("good" = 1), na_values = 10))
   expect_equal(zap_labels(df, user_na = TRUE)$y, 10:1)
 })
+
+test_that("replaces na_range missings for spss", {
+  x <- labelled_spss(1:10, c(low = 1), na_range = c(8, 10))
+  out <- zap_labels(x)
+  expect_equal(out[1:7], 1:7)
+  expect_true(all(is.na(out[8:10])))
+})
+
+test_that("replaces na_range and na_values missings for spss", {
+  x <- labelled_spss(1:10, c(low = 1), na_values = 5, na_range = c(8, 10))
+  out <- zap_labels(x)
+  expect_true(is.na(out[5]))
+  expect_true(all(is.na(out[8:10])))
+  expect_equal(out[c(1:4, 6:7)], c(1:4, 6:7))
+})
+
+test_that("keeps na_range missings for spss if user_na = TRUE", {
+  x <- labelled_spss(1:10, c(low = 1), na_range = c(8, 10))
+  out <- zap_labels(x, user_na = TRUE)
+  expect_equal(out, 1:10)
+})

--- a/vignettes/semantics.Rmd
+++ b/vignettes/semantics.Rmd
@@ -32,7 +32,7 @@ Value labels in SAS are a little different again. In SAS, labels are just specia
 
 ### `labelled()`
 
-To allow you to import labelled vectors into R, haven provides the S3 labelled class, created with `labelled()`. This class allows you to associated arbitrary labels with numeric or character vectors:
+To allow you to import labelled vectors into R, haven provides the S3 labelled class, created with `labelled()`. This class allows you to associate arbitrary labels with numeric or character vectors:
 
 ```{r}
 x1 <- labelled(
@@ -161,7 +161,7 @@ And the presence of that method does mean many functions with an `na.rm` argumen
 mean(x1, na.rm = TRUE)
 ```
 
-But generally you should either convert to a factor, convert to regular missing vaues, or strip the all the labels:
+But generally you should either convert to a factor, convert to regular missing values, or strip the all the labels:
 
 ```{r}
 as_factor(x1)


### PR DESCRIPTION
## Summary

Fixes two typos/grammar errors in the  file:

1. **Line 35**:  →  (verb form error)
2. **Line 164**:  →  (spelling error)

## Context

These are separate from the existing PRs:
- PR #803 fixes  →  on line 31 of the same file
- PR #806 fixes  →  on line 137

## Testing

- * checking for file './DESCRIPTION' ... OK
* preparing 'haven':
* checking DESCRIPTION meta-information ... OK
* cleaning src
* running 'cleanup'
* installing the package to build vignettes
* creating vignettes ... OK
* cleaning src
* running 'cleanup'
* checking for LF line-endings in source and make files and shell scripts
* checking for empty or unneeded directories
* building 'haven_2.5.5.9000.tar.gz' succeeds
- All 472 existing tests pass (1 pre-existing snapshot encoding failure unrelated to this change)

## Related

No related issues. Documentation-only change.