### PR TITLE
docs: add dataset label documentation for read_sas() and read_spss()

### DIFF
--- a/R/haven-sas.R
+++ b/R/haven-sas.R
@@ -27,6 +27,9 @@
 #'   Variable labels are stored in the "label" attribute of each variable. It is
 #'   not printed on the console, but the RStudio viewer will show it.
 #'
+#'   If a dataset label is defined, it will be stored in the "label" attribute
+#'   of the tibble.
+#'
 #' @export
 #' @examples
 #' path <- system.file("examples", "iris.sas7bdat", package = "haven")

--- a/R/haven-spss.R
+++ b/R/haven-spss.R
@@ -21,6 +21,9 @@
 #'   Variable labels are stored in the "label" attribute of each variable.
 #'   It is not printed on the console, but the RStudio viewer will show it.
 #'
+#'   If a dataset label is defined, it will be stored in the "label" attribute
+#'   of the tibble.
+#'
 #'   `write_sav()` returns the input `data` invisibly.
 #' @name read_spss
 #' @examples

--- a/man/read_sas.Rd
+++ b/man/read_sas.Rd
@@ -64,6 +64,9 @@ A tibble, data frame variant with nice defaults.
 
 Variable labels are stored in the "label" attribute of each variable. It is
 not printed on the console, but the RStudio viewer will show it.
+
+If a dataset label is defined, it will be stored in the "label" attribute
+of the tibble.
 }
 \description{
 \code{read_sas()} supports both sas7bdat files and the accompanying sas7bcat files

--- a/man/read_spss.Rd
+++ b/man/read_spss.Rd
@@ -44,13 +44,11 @@ read_spss(
 Files ending in \code{.gz}, \code{.bz2}, \code{.xz}, or \code{.zip} will
 be automatically uncompressed. Files starting with \verb{http://},
 \verb{https://}, \verb{ftp://}, or \verb{ftps://} will be automatically
-downloaded. Remote gz files can also be automatically downloaded and
+downloaded. Remote \code{.gz} files can also be automatically downloaded and
 decompressed.
 
 Literal data is most useful for examples and tests. To be recognised as
-literal data, the input must be either wrapped with \code{I()}, be a string
-containing at least one new line, or be a vector containing at least one
-string with a new line.
+literal data, wrap the input with \code{I()}.
 
 Using a value of \code{\link[readr:clipboard]{clipboard()}} will read from the system clipboard.}
 
@@ -128,6 +126,9 @@ A tibble, data frame variant with nice defaults.
 
 Variable labels are stored in the "label" attribute of each variable.
 It is not printed on the console, but the RStudio viewer will show it.
+
+If a dataset label is defined, it will be stored in the "label" attribute
+of the tibble.
 
 \code{write_sav()} returns the input \code{data} invisibly.
 }


### PR DESCRIPTION
## Summary

`read_dta()` and `read_xpt()` both document that dataset labels are stored in the `"label"` attribute of the tibble, but `read_sas()` and `read_spss()` did not mention this despite using the same C++ code path (`DfReader.cpp:477` — `setMetadata(readstat_get_file_label(...))`).

This PR adds matching documentation to both functions for consistency.

## Changes

- `R/haven-sas.R`: Add dataset label note to `read_sas()` `@return`
- `R/haven-spss.R`: Add dataset label note to `read_spss()` `@return`
- `man/read_sas.Rd`, `man/read_spss.Rd`: Regenerated

## Source evidence

In `src/DfReader.cpp:180-182`:
```cpp
void setMetadata(const char *file_label) {
    if (file_label != NULL && strcmp(file_label, "") != 0) {
        output_.attr("label") = file_label;
    }
}
```

Called at line 477 for all formats:
```cpp
((DfReader*) ctx)->setMetadata(readstat_get_file_label(metadata));
```

## Tests

- `tools::checkRd()` passes on both Rd files
- `devtools::test()` passes (466 passed; 1 pre-existing snapshot failure in `test-labelled-pillar.R:73` unrelated to this change)