### PR TITLE
fix: correct levels doc typo 'label' -> 'labels' in as_factor()

### DIFF
--- a/R/as_factor.R
+++ b/R/as_factor.R
@@ -55,7 +55,7 @@ as_factor.data.frame <- function(x, ..., only_labelled = TRUE) {
 #'   * "default": uses labels where available, otherwise the values.
 #'     Labels are sorted by value.
 #'   * "both": like "default", but pastes together the level and value
-#'   * "label": use only the labels; unlabelled values become `NA`
+#'   * "labels": use only the labels; unlabelled values become `NA`
 #'   * "values": use only the values
 #' @rdname as_factor
 #' @export

--- a/man/as_factor.Rd
+++ b/man/as_factor.Rd
@@ -35,7 +35,7 @@
 \item "default": uses labels where available, otherwise the values.
 Labels are sorted by value.
 \item "both": like "default", but pastes together the level and value
-\item "label": use only the labels; unlabelled values become \code{NA}
+\item "labels": use only the labels; unlabelled values become \code{NA}
 \item "values": use only the values
 }}
 


### PR DESCRIPTION
The roxygen documentation for `as_factor.haven_labelled()` listed the levels option as `"label"` (singular) but the actual code accepts `"labels"` (plural) via `match.arg()`. The example on line 21 correctly uses `levels = "labels"`.

This PR corrects the bullet point in the `@param levels` documentation to match the code.

### Changes
- `R/as_factor.R`: roxygen comment `"label"` -> `"labels"`
- `man/as_factor.Rd`: regenerated

### Validation
- `R CMD build .` succeeds
- `R CMD check --no-manual --no-vignettes` passes (1 pre-existing test failure in test-haven-sas.R:132 unrelated to this change)
- `tools::checkRd("man/as_factor.Rd")` clean