### PR TITLE
docs: fix two remaining typos in semantics.Rmd vignette

### DIFF
--- a/vignettes/semantics.Rmd
+++ b/vignettes/semantics.Rmd
@@ -24,7 +24,7 @@ Base R has one data type that effectively maintains a mapping between integers a
 * SPSS and SAS can label numeric and character values, not just
   integer values.
   
-* The value do not need to be exhaustive. It is common to label the
+* The values do not need to be exhaustive. It is common to label the
   special missing values (e.g. `.D` = did not respond, `.N` = 
   not applicable), while leaving other values as is.
 
@@ -48,7 +48,7 @@ x2 <- labelled(
 x2
 ```
 
-The goal of haven is not to provide a labelled vector that you can use everywhere in your analysis. The goal is to provide an intermediate datastructure that you can convert into a regular R data frame. You can do this by either converting to a factor or stripping the labels:
+The goal of haven is not to provide a labelled vector that you can use everywhere in your analysis. The goal is to provide an intermediate data structure that you can convert into a regular R data frame. You can do this by either converting to a factor or stripping the labels:
 
 ```{r}
 as_factor(x1)


### PR DESCRIPTION
Fixes two remaining typos in  not covered by existing PRs:

- Line 27: 'The value do not need' → 'The values do not need' (subject-verb agreement)
- Line 51: 'datastructure' → 'data structure' (should be two words)

These are distinct from PR #811 (which fixes lines 35 and 164) and PR #803 (which fixes line 31).

### Validation
- * checking for file './DESCRIPTION' ... OK
* preparing 'haven':
* checking DESCRIPTION meta-information ... OK
* cleaning src
* running 'cleanup'
* installing the package to build vignettes
* creating vignettes ... OK
* cleaning src
* running 'cleanup'
* checking for LF line-endings in source and make files and shell scripts
* checking for empty or unneeded directories
* building 'haven_2.5.5.9000.tar.gz' — OK
-  — OK (vignettes build cleanly)
- Pre-existing test failure in  (cols_only deprecation) is unrelated
- Pre-existing NOTE about  is unrelated