### PR TITLE
docs: fix three remaining issues in semantics.Rmd vignette

### DIFF
--- a/vignettes/semantics.Rmd
+++ b/vignettes/semantics.Rmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-There are some differences between the way that R, SAS, SPSS, and Stata represented labelled data and missing values. While SAS, SPSS, and Stata share some obvious similarities, R is little different. This vignette explores the differences, and shows you how haven bridges the gap.
+There are some differences between the way that R, SAS, SPSS, and Stata represent labelled data and missing values. While SAS, SPSS, and Stata share some obvious similarities, R is a little different. This vignette explores the differences, and shows you how haven bridges the gap.
 
 ## Value labels
 
@@ -63,7 +63,7 @@ See the documentation for `as_factor()` for more options to control exactly what
 Both `as_factor()` and `zap_labels()` have data frame methods if you want to apply the same strategy to every column in a data frame:
 
 ```{r}
-df <- tibble::data_frame(x1, x2, z = 1:5)
+df <- tibble::tibble(x1, x2, z = 1:5)
 df
 
 zap_labels(df)
@@ -134,7 +134,7 @@ as_factor(y)
 SPSS's user-defined values work differently to SAS and Stata. Each column can have either up to three distinct values that are considered as missing, or a range.  Haven provides `labelled_spss()` as a subclass of `labelled()` to model these additional user-defined missings. 
 
 ```{r}
-x1 <- labelled_spss(c(1:10, 99), c(Missing = 99), na_value = 99)
+x1 <- labelled_spss(c(1:10, 99), c(Missing = 99), na_values = 99)
 x2 <- labelled_spss(c(1:10, 99), c(Missing = 99), na_range = c(90, Inf))
 
 x1


### PR DESCRIPTION
## Summary

Three fixes for remaining issues in the `semantics.Rmd` vignette:

1. **Line 18**: Fix missing article and verb tense — "R is little different" → "R is a little different"; "represented" → "represent"
2. **Line 66**: Replace deprecated `tibble::data_frame()` with `tibble::tibble()`  
3. **Line 137**: Fix parameter name typo — `na_value = 99` → `na_values = 99` in `labelled_spss()` example

## Scope

Vignette-only change. No R source code or test changes.

## Validation

- `R CMD build .` — OK
- `R CMD check --no-manual --no-vignettes` — Status: OK (only pre-existing NOTE about `setNames`)
- Pre-existing test failure in `test-haven-sas.R:132` is unrelated to this change

## Duplicate check

No overlap with existing PRs:
- PR #811 fixes lines 35 and 164 in the same file
- PR #815 fixes lines 27 and 51 in the same file
- PR #806 fixes `na_value` typo in R/zap_missing.R (not the vignette)
