### PR TITLE
test: add test for write_sas() deprecation warning

### DIFF
--- a/tests/testthat/test-haven-sas.R
+++ b/tests/testthat/test-haven-sas.R
@@ -136,6 +136,12 @@ test_that("using cols_only warns about deprecation, but works", {
   expect_named(out, "id")
 })
 
+test_that("write_sas warns about deprecation", {
+  df <- tibble(x = 1:3)
+  path <- tempfile(fileext = ".sas7bdat")
+  lifecycle::expect_deprecated(write_sas(df, path), "write_sas")
+})
+
 # read_xpt ----------------------------------------------------------------
 
 test_that("can read date/times", {


### PR DESCRIPTION
## Summary

Adds a test verifying that `write_sas()` emits a deprecation warning directing users to `write_xpt()`.

## Changes

- `tests/testthat/test-haven-sas.R`: Added test using `lifecycle::expect_deprecated()` to verify the `write_sas()` deprecation warning (deprecated since haven 2.5.2).

## Testing

- `devtools::test(filter = haven-sas)`: 71 PASS, 1 pre-existing failure (cols_only deprecation test — separate issue with once-per-session dedup)
- `devtools::test()`: 475 PASS, 2 pre-existing failures (labelled-pillar snapshot, haven-sas cols_only dedup)

## Notes

- Uses `lifecycle::expect_deprecated()` instead of `expect_warning()` because `lifecycle::deprecate_warn()` deduplicates across the session, making `expect_warning()` unreliable when tests run after other code has already triggered the warning.
- No overlap with existing PRs.