### PR TITLE
test: add compress=TRUE/FALSE backwards compat test for write_sav()

### DIFF
--- a/tests/testthat/test-haven-spss.R
+++ b/tests/testthat/test-haven-spss.R
@@ -430,3 +430,9 @@ test_that("all compression types roundtrip successfully", {
   expect_equal(roundtrip_sav(df, compress = "none"), df)
   expect_equal(roundtrip_sav(df, compress = "zsav"), df)
 })
+
+test_that("compress accepts TRUE/FALSE for backwards compatibility", {
+  df <- tibble::tibble(x = 1:10)
+  expect_equal(roundtrip_sav(df, compress = TRUE), df)
+  expect_equal(roundtrip_sav(df, compress = FALSE), df)
+})


### PR DESCRIPTION
## What

Adds a test for `write_sav(compress = TRUE)` and `write_sav(compress = FALSE)`, which are documented backwards-compatible alternatives to `"zsav"` and `"none"` respectively.

## Why

The `write_sav()` docs state:

> `TRUE` and `FALSE` can be used for backwards compatibility, and correspond to the "zsav" and "none" options respectively.

But only the string values (`"byte"`, `"none"`, `"zsav"`) were tested. The `TRUE`/`FALSE` code path in `R/haven-spss.R:96-99` had no test coverage.

## Tests run

```
devtools::test(filter = "haven-spss")
# [ FAIL 0 | WARN 1 | SKIP 0 | PASS 98 ]
```

The 1 warning is a pre-existing Unicode encoding issue on macOS, unrelated to this change.