### PR TITLE
fix: guard against zero-length label/format attributes in write functions (#740)

### DIFF
--- a/src/DfWriter.cpp
+++ b/src/DfWriter.cpp
@@ -113,7 +113,7 @@ public:
   }
 
   void setFileLabel(cpp11::sexp label) {
-    if (label == R_NilValue)
+    if (label == R_NilValue || Rf_length(label) == 0)
       return;
 
     readstat_writer_set_file_label(writer_, string_utf8(label, 0));
@@ -229,7 +229,7 @@ public:
   const char* var_label(cpp11::sexp x) {
     cpp11::sexp label(x.attr("label"));
 
-    if (label == R_NilValue)
+    if (label == R_NilValue || Rf_length(label) == 0)
       return NULL;
 
     return string_utf8(label, 0);
@@ -238,7 +238,7 @@ public:
   const char* var_format(cpp11::sexp x, VarType varType) {
     // Use attribute, if present
     cpp11::sexp format(x.attr(formatAttribute(vendor_).c_str()));
-    if (format != R_NilValue)
+    if (format != R_NilValue && Rf_length(format) != 0)
       return string_utf8(format, 0);
 
     switch(varType) {

--- a/tests/testthat/test-haven-stata.R
+++ b/tests/testthat/test-haven-stata.R
@@ -257,6 +257,24 @@ test_that("can roundtrip long strings (strL)", {
 })
 
 
+test_that("zero-length label attributes don't cause crash (#740)", {
+  # Zero-length variable label
+  df <- data.frame(
+    not_working = structure(5:1, format.stata = "%10.0g", label = character(0)),
+    working = 1:5
+  )
+  path <- tempfile(fileext = ".dta")
+  expect_no_error(write_dta(df, path))
+
+  result <- read_dta(path)
+  expect_null(attr(result$not_working, "label"))
+
+  # Zero-length format attribute
+  df2 <- data.frame(x = structure(1:3, format.stata = character(0)))
+  path2 <- tempfile(fileext = ".dta")
+  expect_no_error(write_dta(df2, path2))
+})
+
 test_that("invisibly returns original data unaltered", {
   df <- tibble(
     x = 1:5,


### PR DESCRIPTION
Fixes #740

## Problem
When a variable has `label = character(0)` (zero-length character vector), `STRING_ELT(x, 0)` returns `NULL`, causing `Rf_translateCharUTF8` to crash with an error about CHARSXP.

This affects `write_dta()`, `write_sav()`, and `write_xpt()`.

## Fix
Added `Rf_length()` checks in three functions in `DfWriter.cpp`:
- `var_label()` - treats zero-length label as no label (returns NULL)
- `var_format()` - treats zero-length format as no format (falls through to default)
- `setFileLabel()` - treats zero-length file label as no label (skips)

## Changes
- `src/DfWriter.cpp`: 3 guard clauses added (1-line change each)
- `tests/testthat/test-haven-stata.R`: new test covering zero-length variable label and format attributes

## Testing
- Reprex from issue #740 now works without error
- All 64 Stata tests pass (0 failures)
- Full test suite: 439 PASS, 1 pre-existing FAILURE (SAS deprecation test unrelated to this change)
