### PR TITLE
docs: add @return and @examples to zap_formats() and zap_widths()

### DIFF
--- a/R/zap_formats.R
+++ b/R/zap_formats.R
@@ -6,8 +6,19 @@
 #' code, you can get rid of them with `zap_formats`.
 #'
 #' @param x A vector or data frame.
+#' @return The input with format attributes (`format.spss`, `format.sas`,
+#'   `format.stata`) removed.
 #' @family zappers
 #' @export
+#' @examples
+#' x <- labelled(c(1, 2, 3), c(yes = 1, no = 3))
+#' attr(x, "format.spss") <- "F8.2"
+#' attr(x, "format.stata") <- "%8.2g"
+#' zap_formats(x)
+#'
+#' # Also works with data frames
+#' df <- tibble::tibble(x = x, y = 4:6)
+#' zap_formats(df)
 zap_formats <- function(x) {
   UseMethod("zap_formats")
 }

--- a/R/zap_widths.R
+++ b/R/zap_widths.R
@@ -5,8 +5,17 @@
 #' causes problems for your code, you can get rid of them with `zap_widths`.
 #'
 #' @param x A vector or data frame.
+#' @return The input with `display_width` attributes removed.
 #' @family zappers
 #' @export
+#' @examples
+#' x <- labelled(c(1, 2, 3), c(yes = 1, no = 3))
+#' attr(x, "display_width") <- 10
+#' zap_widths(x)
+#'
+#' # Also works with data frames
+#' df <- tibble::tibble(x = x, y = 4:6)
+#' zap_widths(df)
 zap_widths <- function(x) {
   UseMethod("zap_widths")
 }

--- a/man/zap_formats.Rd
+++ b/man/zap_formats.Rd
@@ -9,17 +9,31 @@ zap_formats(x)
 \arguments{
 \item{x}{A vector or data frame.}
 }
+\value{
+The input with format attributes (\code{format.spss}, \code{format.sas},
+\code{format.stata}) removed.
+}
 \description{
 To provide some mild support for round-tripping variables between Stata/SPSS
 and R, haven stores variable formats in an attribute: \code{format.stata},
 \code{format.spss}, or \code{format.sas}. If this causes problems for your
 code, you can get rid of them with \code{zap_formats}.
 }
+\examples{
+x <- labelled(c(1, 2, 3), c(yes = 1, no = 3))
+attr(x, "format.spss") <- "F8.2"
+attr(x, "format.stata") <- "\%8.2g"
+zap_formats(x)
+
+# Also works with data frames
+df <- tibble::tibble(x = x, y = 4:6)
+zap_formats(df)
+}
 \seealso{
-Other zappers: 
-\code{\link{zap_empty}()},
-\code{\link{zap_label}()},
-\code{\link{zap_labels}()},
-\code{\link{zap_widths}()}
+Other zappers:
+\code{\link[=zap_empty]{zap_empty()}},
+\code{\link[=zap_label]{zap_label()}},
+\code{\link[=zap_labels]{zap_labels()}},
+\code{\link[=zap_widths]{zap_widths()}}
 }
 \concept{zappers}

--- a/man/zap_widths.Rd
+++ b/man/zap_widths.Rd
@@ -9,16 +9,28 @@ zap_widths(x)
 \arguments{
 \item{x}{A vector or data frame.}
 }
+\value{
+The input with \code{display_width} attributes removed.
+}
 \description{
 To provide some mild support for round-tripping variables between SPSS
 and R, haven stores display widths in an attribute: \code{display_width}. If this
 causes problems for your code, you can get rid of them with \code{zap_widths}.
 }
+\examples{
+x <- labelled(c(1, 2, 3), c(yes = 1, no = 3))
+attr(x, "display_width") <- 10
+zap_widths(x)
+
+# Also works with data frames
+df <- tibble::tibble(x = x, y = 4:6)
+zap_widths(df)
+}
 \seealso{
-Other zappers: 
-\code{\link{zap_empty}()},
-\code{\link{zap_formats}()},
-\code{\link{zap_label}()},
-\code{\link{zap_labels}()}
+Other zappers:
+\code{\link[=zap_empty]{zap_empty()}},
+\code{\link[=zap_formats]{zap_formats()}},
+\code{\link[=zap_label]{zap_label()}},
+\code{\link[=zap_labels]{zap_labels()}}
 }
 \concept{zappers}


### PR DESCRIPTION
## Summary

Adds missing `@return` and `@examples` roxygen documentation to `zap_formats()` and `zap_widths()`.

These are the only two `zap_*` functions that were missing `@examples` sections. All other `zap_*` functions (`zap_empty`, `zap_label`, `zap_labels`, `zap_missing`) already had both `@return` and `@examples`.

Complementary to PR #817 which adds `@return` tags to all `zap_*` functions.

## Changes

| File | Change |
|------|--------|
| `R/zap_formats.R` | Added `@return` and `@examples` |
| `R/zap_widths.R` | Added `@return` and `@examples` |
| `man/zap_formats.Rd` | Regenerated Rd |
| `man/zap_widths.Rd` | Regenerated Rd |

## Examples style

Examples follow the same pattern as the other `zap_*` functions:
- Create a labelled vector
- Set the relevant attribute
- Show the zap function removing it
- Demonstrate data frame usage

## Validation

- `devtools::test(filter = "zap")`: 23 PASS, 0 failures
- `devtools::test()` full suite: 465 PASS, 2 pre-existing snapshot failures (encoding-related, unrelated)